### PR TITLE
feat: self-documenting agent

### DIFF
--- a/src/agent/container-runner.ts
+++ b/src/agent/container-runner.ts
@@ -4,7 +4,8 @@ import {
   spawn,
 } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AppConfig } from "../config.js";
 import { type Logger, logger } from "../logger.js";
 import { getApiKeyFromPiAuthFile } from "../storage/pi-auth.js";
@@ -15,6 +16,9 @@ const START = "---CLAWBBER_CONTAINER_RESULT_START---";
 const END = "---CLAWBBER_CONTAINER_RESULT_END---";
 
 const CONTAINER_LABEL = "clawbber.managed=true";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.join(__dirname, "../..");
 
 /** Exit code 137 = SIGKILL (128 + 9), typically from OOM killer */
 const OOM_EXIT_CODE = 137;
@@ -173,6 +177,10 @@ export class AgentContainerRunner {
 
     const containerName = this.generateContainerName();
 
+    // Resolve docs paths for self-documenting agent
+    const docsDir = path.resolve(PACKAGE_ROOT, "docs");
+    const readmePath = path.resolve(PACKAGE_ROOT, "README.md");
+
     const args = [
       "run",
       "--rm",
@@ -185,6 +193,10 @@ export class AgentContainerRunner {
       `${groupsRoot}:/groups`,
       "-v",
       `${globalDir}:/home/node/.pi/agent`,
+      "-v",
+      `${readmePath}:/docs/clawbber/README.md:ro`,
+      "-v",
+      `${docsDir}:/docs/clawbber/docs:ro`,
     ];
 
     for (const { key, value } of envPairs) {

--- a/src/cli/clawbber.ts
+++ b/src/cli/clawbber.ts
@@ -143,6 +143,22 @@ agent-browser get text body
 - Long-running tasks may time out
 - No persistent memory between conversations
 
+## Clawbber Documentation
+
+When users ask about clawbber's capabilities, configuration, or how things work, read the relevant docs:
+
+| Path | Contents |
+|------|----------|
+| /docs/clawbber/README.md | Overview, commands, triggers, permissions, tasks, config |
+| /docs/clawbber/docs/ingress.md | Adapter message flow (WhatsApp, Slack, Discord) |
+| /docs/clawbber/docs/media/ | Media handling (downloads, attachments) |
+| /docs/clawbber/docs/subagents.md | Delegating to sub-agents |
+| /docs/clawbber/docs/web-search.md | Web search capabilities |
+| /docs/clawbber/docs/auth/ | Platform authentication |
+| /docs/clawbber/docs/rate-limiting.md | Rate limiting configuration |
+
+Read these lazily — only when the user asks about a specific topic.
+
 ## Sub-agents
 
 You can delegate tasks to specialized sub-agents:


### PR DESCRIPTION
## Summary

Make the agent inside the container aware of clawbber's documentation so it can answer questions like "what can you do?" or "how do scheduled tasks work?"

## Changes

- **src/agent/container-runner.ts** — Mount README.md and docs/ into container at `/docs/clawbber/`
- **src/cli/clawbber.ts** — Add documentation reference table to AGENTS.md template

## Container Mounts

| Host | Container | Mode |
|------|-----------|------|
| `README.md` | `/docs/clawbber/README.md` | ro |
| `docs/` | `/docs/clawbber/docs/` | ro |

## AGENTS.md Addition

```markdown
## Clawbber Documentation

When users ask about clawbber's capabilities, configuration, or how things work, read the relevant docs:

| Path | Contents |
|------|----------|
| /docs/clawbber/README.md | Overview, commands, triggers, permissions, tasks, config |
| /docs/clawbber/docs/ingress.md | Adapter message flow |
| /docs/clawbber/docs/media/ | Media handling |
| ... | ... |
```

## Testing

```bash
bun run check  # All 235 tests pass
```

Closes #15