### PR TITLE
Memory Phase 1: Core vault structure + Napkin integration

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,8 +3,9 @@
 
 FROM oven/bun:1.3
 
-# Install pi CLI globally at build time
+# Install pi CLI and napkin-ai globally at build time
 RUN bun add -g @mariozechner/pi-coding-agent
+RUN bun add -g napkin-ai
 
 WORKDIR /app
 

--- a/src/agent/container-entry.ts
+++ b/src/agent/container-entry.ts
@@ -28,10 +28,37 @@ function formatContextTimestamp(ms: number): string {
 }
 
 function buildSystemPrompt(): string {
-  return [
-    "You are Mercury, a concise personal AI assistant.",
-    "Prioritize practical outputs and explicit assumptions.",
-  ].join("\n");
+  return `You are Mercury, a concise personal AI assistant.
+Prioritize practical outputs and explicit assumptions.
+
+## Memory
+
+You have a persistent memory system powered by napkin (Obsidian-compatible vault).
+Your workspace is organized with entities/, daily/, and AGENTS.md for persistent instructions.
+
+### Reading memory
+- Use \`napkin search "query"\` to find relevant files
+- Use \`napkin read "filename"\` to read a specific file
+- Use \`napkin link back --file "name"\` to see what links to a file
+- Use \`napkin daily read\` to read today's daily note
+
+### Writing memory
+- When the user asks you to remember something, write it immediately using napkin.
+- For new entities: \`napkin create --name "Entity Name" --path entities --content "..."\`
+- For existing entities: \`napkin append --file "Entity Name" --content "..."\`
+- For structured facts: \`napkin property set --file "Entity Name" --name key --value "value"\`
+- For conversation context: \`napkin daily append --content "..."\`
+- For persistent instructions: Edit AGENTS.md directly
+
+### Wikilinks
+- Use \`[[Like This]]\` when mentioning people, places, projects, or concepts
+- Pages are cheap — if in doubt, link it
+- napkin resolves wikilinks automatically
+
+### What to remember
+- Everything the user explicitly asks you to remember
+- Context needed to continue the conversation tomorrow
+- Don't filter by "importance" — if it came up, it may matter later`;
 }
 
 /**

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const PI_SUBDIRS = [".pi", ".pi/extensions", ".pi/skills", ".pi/prompts"];
+const VAULT_DIRS = [".obsidian", "entities", "daily"];
 
 /**
  * Ensure a pi resource directory exists with standard structure.
@@ -21,7 +22,18 @@ export function ensurePiResourceDir(dir: string): void {
 }
 
 /**
- * Ensure a per-group workspace exists with the pi resource structure.
+ * Ensure vault structure exists in a workspace directory.
+ * Creates .obsidian/, entities/, daily/ directories for napkin compatibility.
+ */
+export function ensureVaultStructure(dir: string): void {
+  for (const sub of VAULT_DIRS) {
+    fs.mkdirSync(path.join(dir, sub), { recursive: true });
+  }
+}
+
+/**
+ * Ensure a per-group workspace exists with the pi resource structure
+ * and Obsidian-compatible vault structure.
  */
 export function ensureGroupWorkspace(
   groupsDir: string,
@@ -31,6 +43,7 @@ export function ensureGroupWorkspace(
   const dir = path.join(groupsDir, safeGroup);
 
   ensurePiResourceDir(dir);
+  ensureVaultStructure(dir);
 
   return dir;
 }

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureGroupWorkspace } from "../src/storage/memory.js";
+
+describe("ensureGroupWorkspace with vault structure", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "mercury-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should create vault directories", () => {
+    const workspace = ensureGroupWorkspace(tempDir, "test-group");
+
+    expect(existsSync(join(workspace, ".obsidian"))).toBe(true);
+    expect(existsSync(join(workspace, "entities"))).toBe(true);
+    expect(existsSync(join(workspace, "daily"))).toBe(true);
+  });
+
+  it("should create pi resource directories", () => {
+    const workspace = ensureGroupWorkspace(tempDir, "test-group");
+
+    expect(existsSync(join(workspace, ".pi"))).toBe(true);
+    expect(existsSync(join(workspace, ".pi/extensions"))).toBe(true);
+    expect(existsSync(join(workspace, ".pi/skills"))).toBe(true);
+    expect(existsSync(join(workspace, ".pi/prompts"))).toBe(true);
+  });
+
+  it("should create AGENTS.md", () => {
+    const workspace = ensureGroupWorkspace(tempDir, "test-group");
+
+    expect(existsSync(join(workspace, "AGENTS.md"))).toBe(true);
+  });
+
+  it("should sanitize group id for directory name", () => {
+    const workspace = ensureGroupWorkspace(tempDir, "test@group#123");
+
+    expect(workspace).toBe(join(tempDir, "test_group_123"));
+    expect(existsSync(workspace)).toBe(true);
+  });
+
+  it("should be idempotent", () => {
+    const workspace1 = ensureGroupWorkspace(tempDir, "test-group");
+    const workspace2 = ensureGroupWorkspace(tempDir, "test-group");
+
+    expect(workspace1).toBe(workspace2);
+    expect(existsSync(join(workspace1, ".obsidian"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Sets up the foundational memory system using Obsidian-compatible vaults and napkin CLI.

## Changes

- **Vault structure**: `ensureGroupWorkspace` now creates `.obsidian/`, `entities/`, `daily/` directories for napkin compatibility
- **Napkin in container**: Added `napkin-ai` to container image
- **Agent system prompt**: Added memory section with napkin usage instructions

## How it works

The agent uses napkin CLI for all memory operations:
- `napkin search` to find relevant context
- `napkin create/append` to write entities
- `napkin daily` for conversation logs
- `napkin link` for graph traversal
- `AGENTS.md` for persistent instructions (already loaded by pi)

No custom retrieval logic — napkin handles everything.

## Tests

- Added vault structure tests in `tests/memory.test.ts`
- All existing tests pass

Closes #35