### PR TITLE
feat: add silent flag for scheduled tasks

### DIFF
--- a/src/cli/mercury-ctl.ts
+++ b/src/cli/mercury-ctl.ts
@@ -51,7 +51,7 @@ function usage(): never {
 Usage:
   mercury-ctl whoami
   mercury-ctl tasks list
-  mercury-ctl tasks create --cron <expr> --prompt <text>
+  mercury-ctl tasks create --cron <expr> --prompt <text> [--silent]
   mercury-ctl tasks pause <id>
   mercury-ctl tasks resume <id>
   mercury-ctl tasks run <id>
@@ -108,9 +108,12 @@ async function main() {
         case "create": {
           const cron = parseFlag(args, "--cron");
           const prompt = parseFlag(args, "--prompt");
+          const silent = args.includes("--silent");
           if (!cron || !prompt)
-            fatal("Usage: tasks create --cron <expr> --prompt <text>");
-          print(await api("POST", "/api/tasks", { cron, prompt }));
+            fatal(
+              "Usage: tasks create --cron <expr> --prompt <text> [--silent]",
+            );
+          print(await api("POST", "/api/tasks", { cron, prompt, silent }));
           break;
         }
         case "pause": {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -24,6 +24,7 @@ interface ApiContext {
 interface TaskCreateBody {
   cron?: string;
   prompt?: string;
+  silent?: boolean;
 }
 
 interface ConfigSetBody {
@@ -131,14 +132,22 @@ export function handleApiRequest(
           currentDate: new Date(),
         });
         const nextRunAt = interval.next().getTime();
+        const silent = body.silent ?? false;
         const id = ctx.db.createTask(
           groupId,
           body.cron,
           body.prompt,
           nextRunAt,
           callerId,
+          silent,
         );
-        return json({ id, cron: body.cron, prompt: body.prompt, nextRunAt });
+        return json({
+          id,
+          cron: body.cron,
+          prompt: body.prompt,
+          silent,
+          nextRunAt,
+        });
       } catch {
         return error("Invalid cron expression", 400);
       }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -59,7 +59,9 @@ export class MercuryCoreRuntime {
         "scheduler",
         task.createdBy,
       );
-      if (sender) await sender.send(task.groupId, reply);
+      if (!task.silent && sender) {
+        await sender.send(task.groupId, reply);
+      }
     });
   }
 

--- a/src/core/task-scheduler.ts
+++ b/src/core/task-scheduler.ts
@@ -7,6 +7,7 @@ type TaskHandler = (task: {
   groupId: string;
   prompt: string;
   createdBy: string;
+  silent: boolean;
 }) => Promise<void>;
 
 export class TaskScheduler {
@@ -34,6 +35,7 @@ export class TaskScheduler {
               groupId: task.groupId,
               prompt: task.prompt,
               createdBy: task.createdBy,
+              silent: task.silent === 1,
             });
           } catch (error) {
             logger.error("Scheduler task handler failed", {
@@ -77,6 +79,7 @@ export class TaskScheduler {
       groupId: task.groupId,
       prompt: task.prompt,
       createdBy: task.createdBy,
+      silent: task.silent === 1,
     });
     return true;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface ScheduledTask {
   cron: string;
   prompt: string;
   active: number;
+  silent: number;
   nextRunAt: number;
   createdBy: string;
   createdAt: number;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -214,6 +214,50 @@ describe("tasks", () => {
     const task = db.getTask(id);
     expect(task?.nextRunAt).toBe(2000);
   });
+
+  test("createTask with silent flag", () => {
+    db.ensureGroup("g1");
+    const id = db.createTask(
+      "g1",
+      "* * * * *",
+      "silent task",
+      Date.now(),
+      "user1",
+      true,
+    );
+
+    const task = db.getTask(id);
+    expect(task?.silent).toBe(1);
+  });
+
+  test("createTask defaults to not silent", () => {
+    db.ensureGroup("g1");
+    const id = db.createTask("g1", "* * * * *", "task", Date.now(), "user1");
+
+    const task = db.getTask(id);
+    expect(task?.silent).toBe(0);
+  });
+
+  test("listTasks includes silent field", () => {
+    db.ensureGroup("g1");
+    db.createTask("g1", "* * * * *", "normal", Date.now(), "user1", false);
+    db.createTask("g1", "* * * * *", "silent", Date.now(), "user1", true);
+
+    const tasks = db.listTasks("g1");
+    expect(tasks.length).toBe(2);
+    expect(tasks[0].silent).toBe(0);
+    expect(tasks[1].silent).toBe(1);
+  });
+
+  test("getDueTasks includes silent field", () => {
+    db.ensureGroup("g1");
+    const now = Date.now();
+    db.createTask("g1", "* * * * *", "silent due", now - 1000, "user1", true);
+
+    const due = db.getDueTasks(now);
+    expect(due.length).toBe(1);
+    expect(due[0].silent).toBe(1);
+  });
 });
 
 describe("roles", () => {


### PR DESCRIPTION
Silent tasks execute but don't post results to chat. Useful for maintenance tasks, health checks, and background updates.

## Changes

- Add `silent` column to tasks table with migration for existing DBs
- Add `--silent` flag to `mercury-ctl tasks create`
- Skip sending reply when `task.silent` is true
- Update docs/scheduler.md
- Add 4 tests for silent flag behavior

## Usage

```bash
mercury-ctl tasks create --cron "0 3 * * *" --prompt "Run maintenance" --silent
```

Closes #43