### PR TITLE
feat: KB distillation system

### DIFF
--- a/docs/kb-distillation.md
+++ b/docs/kb-distillation.md
@@ -1,0 +1,232 @@
+# KB Distillation
+
+Mercury can automatically extract lasting knowledge from conversations and save it to an Obsidian-compatible vault. The KB distiller runs periodically, processing daily message logs and updating entity files.
+
+## How It Works
+
+```
+Runtime (interval)
+  │
+  └─► kbDistill()
+        │
+        ├─► Export messages to .messages/YYYY-MM-DD.jsonl
+        │
+        ├─► Compare MD5 hash before/after
+        │
+        ├─► If changed → run kb-distiller agent
+        │
+        └─► Agent updates vault (entities/, daily/)
+```
+
+The distiller exports messages from the database to daily JSONL files. If a file's content changed (detected via MD5 hash), it runs an AI agent to extract knowledge and update the vault.
+
+## Message Export
+
+Messages are exported to daily partition files:
+
+```
+.mercury/groups/<group-id>/
+├── .messages/
+│   ├── 2026-02-28.jsonl
+│   └── 2026-03-01.jsonl
+└── entities/
+    └── ...                  # Distilled knowledge
+```
+
+Each line in the JSONL file:
+
+```json
+{"ts":1709123456,"role":"ambient","content":"Alice: Great idea!"}
+{"ts":1709123457,"role":"user","content":"What do you think about X?"}
+{"ts":1709123458,"role":"assistant","content":"I think..."}
+```
+
+| Role | Description |
+|------|-------------|
+| `ambient` | Group chat message (format: `Name: content`) |
+| `user` | Message that triggered the assistant |
+| `assistant` | Assistant's response |
+
+## Configuration
+
+Enable via environment variable:
+
+```bash
+# Run every hour (3600000ms)
+MERCURY_KB_DISTILL_INTERVAL_MS=3600000
+
+# Disable (default)
+MERCURY_KB_DISTILL_INTERVAL_MS=0
+```
+
+| Value | Behavior |
+|-------|----------|
+| `0` | Disabled (default) |
+| `> 0` | Runs on that interval in milliseconds |
+
+When enabled, distillation runs immediately on startup, then every interval.
+
+## CLI Usage
+
+Run manually via CLI:
+
+```bash
+# Process today's changed messages
+mercury kb-distill
+
+# Process all changed historical messages
+mercury kb-distill --backfill
+```
+
+## What Gets Extracted
+
+The distiller extracts three types of knowledge:
+
+### People
+
+Created when someone has 3+ messages, shares a resource, or states a clear position.
+
+```markdown
+# Alice
+
+## Expertise
+- AI agents
+- Product development
+
+## Positions
+- Believes agents will replace traditional apps
+
+## Resources Shared
+- [[some-tool]]
+```
+
+### Resources
+
+Tools, repos, articles, or URLs shared in conversation.
+
+```markdown
+# Some Tool
+
+Type: tool
+URL: https://example.com
+Shared by: [[alice]] on 2026-02-28
+
+## What it does
+Description of the tool.
+
+## Why shared
+Context for why it was mentioned.
+```
+
+### Group Knowledge
+
+Decisions and conclusions reached by the group.
+
+```markdown
+# Architecture Decision
+
+Date: 2026-02-28
+Participants: [[alice]], [[bob]]
+
+## Question
+Should we use approach A or B?
+
+## Conclusion
+Go with approach A for reasons X, Y, Z.
+```
+
+## Vault Structure
+
+Distilled knowledge goes into the group's existing vault:
+
+```
+.mercury/groups/<group-id>/
+├── .messages/              # Input (JSONL files)
+├── entities/
+│   ├── people/             # Person entities
+│   ├── resources/          # Tools, repos, articles
+│   └── group-knowledge/    # Decisions, conclusions
+├── daily/                  # Daily notes
+└── .obsidian/              # Obsidian compatibility
+```
+
+## Change Detection
+
+The distiller uses MD5 hashing to detect changes:
+
+1. Read existing JSONL file (if any) and compute hash
+2. Regenerate file from database
+3. Compute hash of new content
+4. If hashes differ → file changed → run distiller
+
+This avoids unnecessary distillation runs when no new messages arrived.
+
+## Incremental Updates
+
+The distiller agent is idempotent:
+
+1. Searches vault before creating entities
+2. Appends to existing files rather than overwriting
+3. Skips already-processed information
+
+This means running distillation multiple times on the same data is safe.
+
+## What Gets Skipped
+
+The distiller ignores:
+
+- Thin interactions (greetings, acknowledgments)
+- Encyclopedia-style definitions
+- Transient chatter
+- `<reply_to>` blocks (quoted messages)
+- Tool outputs
+
+## Lifecycle
+
+```
+mercury run
+  │
+  ├─► runtime.initialize()
+  │
+  ├─► startKbDistill()
+  │     ├─► Run immediately
+  │     └─► Schedule interval
+  │
+  ├─► ... running ...
+  │
+  └─► SIGTERM/SIGINT
+        └─► stopKbDistill()
+              └─► Clear interval (graceful)
+```
+
+## Dependencies
+
+- **[pi](https://github.com/mariozechner/pi)** — Agent runtime
+- **[napkin](https://github.com/michaelliv/napkin-ai)** — Obsidian vault CLI
+
+Both must be installed and available in PATH.
+
+## Backfill
+
+To process historical conversations:
+
+```bash
+mercury kb-distill --backfill
+```
+
+This processes all changed JSONL files across all dates. Safe to run multiple times.
+
+## Troubleshooting
+
+### No changes to distill
+
+The distiller only runs when file content has changed. If messages haven't changed since the last export, nothing happens.
+
+### Force re-distillation
+
+Delete the JSONL files to force regeneration:
+
+```bash
+rm .mercury/groups/<group-id>/.messages/*.jsonl
+mercury kb-distill --backfill
+```

--- a/scripts/kb-distill-cron.sh
+++ b/scripts/kb-distill-cron.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# KB Distillation cron wrapper
+# Usage: Add to crontab: 0 * * * * /path/to/mercury/scripts/kb-distill-cron.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Source .env if exists
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+exec bun run src/cli/mercury.ts kb-distill

--- a/src/chat-sdk.ts
+++ b/src/chat-sdk.ts
@@ -221,6 +221,7 @@ async function main() {
   };
 
   core.startScheduler(messageSender);
+  core.startKbDistill();
   await bot.initialize();
 
   const webhooks = bot.webhooks as Record<string, WebhookHandler>;

--- a/src/cli/kb-distill.ts
+++ b/src/cli/kb-distill.ts
@@ -1,0 +1,343 @@
+#!/usr/bin/env bun
+
+/**
+ * KB Distillation CLI
+ *
+ * Exports messages to daily JSONL files and runs kb-distiller on them.
+ *
+ * Usage:
+ *   mercury kb-distill              # Process today's messages
+ *   mercury kb-distill --backfill   # Process all historical messages
+ */
+
+import { Database } from "bun:sqlite";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { logger } from "../logger.js";
+
+const KB_DISTILLER_PROMPT = `You are a KB distillation agent. Extract lasting knowledge from conversations and save to an Obsidian vault.
+
+## Input
+
+You receive a path to a JSONL file. Each line is:
+\`\`\`json
+{"ts":1709123456,"role":"ambient|user|assistant","content":"..."}
+\`\`\`
+
+**Roles:**
+- \`ambient\` = Group chat message. Format: \`Name: message content\`
+- \`user\` = Message that triggered the assistant
+- \`assistant\` = Assistant's response
+
+## Vault
+
+Current directory is the vault. Use \`--vault .\` with napkin.
+
+## Incremental Updates
+
+Check before creating:
+1. \`napkin search --vault . "name"\`
+2. Exists → \`napkin append\`
+3. New → \`napkin create\`
+
+## Extract
+
+### PEOPLE (3+ messages OR shared resource OR clear position)
+\`\`\`markdown
+# [Person Name]
+
+## Expertise
+- [topics]
+
+## Positions
+- [opinions]
+
+## Resources Shared
+- [[resource]]
+\`\`\`
+
+### RESOURCES (tools, repos, URLs)
+\`\`\`markdown
+# [Resource Name]
+
+Type: tool | repo | article
+URL: [if shared]
+Shared by: [[person]] on [date]
+
+## What it does
+## Why shared
+\`\`\`
+
+### GROUP KNOWLEDGE (decisions only)
+\`\`\`markdown
+# [Topic]
+
+Date: [date]
+Participants: [[person-a]], [[person-b]]
+
+## Question
+## Conclusion
+\`\`\`
+
+## Skip
+
+- Thin interactions
+- Encyclopedia definitions  
+- Transient chatter
+- \`<reply_to>\` blocks
+- Tool outputs
+
+## Napkin Commands
+
+\`\`\`bash
+# Search vault
+napkin search --vault . "query"
+
+# Read file
+napkin read --vault . "path/to/file.md"
+
+# Create new file
+napkin create --vault . --path "entities/people/name.md" --content "..."
+
+# Append to existing
+napkin append --vault . --path "entities/people/name.md" --content "..."
+
+# Daily note
+napkin daily append --vault . --content "..."
+\`\`\`
+
+## Conventions
+
+- Files: \`kebab-case.md\`
+- Links: \`[[lowercase]]\`
+- Paths: \`entities/people/\`, \`entities/resources/\`, \`entities/group-knowledge/\`
+
+## Output
+
+\`\`\`
+## Files Created/Updated
+- path - description
+
+## Skipped
+- reason
+\`\`\`
+`;
+
+export interface KbDistillOptions {
+  dataDir: string;
+  backfill?: boolean;
+  dryRun?: boolean;
+}
+
+interface MessageRow {
+  role: string;
+  content: string;
+  createdAt: number;
+}
+
+interface ExportedMessage {
+  ts: number;
+  role: string;
+  content: string;
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+function todayDate(): string {
+  return formatDate(Date.now());
+}
+
+function exportMessageToJsonl(msg: MessageRow): ExportedMessage {
+  return {
+    ts: msg.createdAt,
+    role: msg.role,
+    content: msg.content,
+  };
+}
+
+function getMessagesDir(groupWorkspace: string): string {
+  return join(groupWorkspace, ".messages");
+}
+
+function getDateFile(messagesDir: string, date: string): string {
+  return join(messagesDir, `${date}.jsonl`);
+}
+
+function md5(content: string): string {
+  return new Bun.CryptoHasher("md5").update(content).digest("hex");
+}
+
+/**
+ * Export messages from DB to daily JSONL files for a group.
+ * Returns set of dates that changed (need distillation).
+ */
+export function exportMessages(
+  db: Database,
+  groupId: string,
+  groupWorkspace: string,
+): Set<string> {
+  const messagesDir = getMessagesDir(groupWorkspace);
+  mkdirSync(messagesDir, { recursive: true });
+
+  const rows = db
+    .query(
+      `SELECT role, content, created_at as createdAt
+       FROM messages
+       WHERE group_id = ?
+       ORDER BY id ASC`,
+    )
+    .all(groupId) as MessageRow[];
+
+  // Group by date
+  const byDate = new Map<string, ExportedMessage[]>();
+  for (const row of rows) {
+    const date = formatDate(row.createdAt);
+    if (!byDate.has(date)) byDate.set(date, []);
+    byDate.get(date)?.push(exportMessageToJsonl(row));
+  }
+
+  // Write files, track which changed
+  const changed = new Set<string>();
+  for (const [date, messages] of byDate) {
+    const filePath = getDateFile(messagesDir, date);
+    const newContent = `${messages.map((m) => JSON.stringify(m)).join("\n")}\n`;
+
+    const oldHash = existsSync(filePath)
+      ? md5(readFileSync(filePath, "utf-8"))
+      : "";
+    writeFileSync(filePath, newContent);
+    const newHash = md5(newContent);
+
+    if (oldHash !== newHash) {
+      changed.add(date);
+    }
+  }
+
+  return changed;
+}
+
+/**
+ * Run kb-distiller on a specific date's messages
+ */
+async function runDistiller(
+  groupWorkspace: string,
+  dateFile: string,
+): Promise<boolean> {
+  const task = `Distill knowledge from: ${dateFile}`;
+
+  // Write prompt to temp file
+  const promptFile = join(tmpdir(), `kb-distiller-${process.pid}.md`);
+  writeFileSync(promptFile, KB_DISTILLER_PROMPT);
+
+  return new Promise((resolve) => {
+    const child = spawn(
+      "pi",
+      [
+        "--print",
+        "--no-session",
+        "--tools",
+        "read,bash,write",
+        "--append-system-prompt",
+        promptFile,
+        task,
+      ],
+      { cwd: groupWorkspace, env: process.env, stdio: "inherit" },
+    );
+
+    child.on("close", (code) => {
+      try {
+        unlinkSync(promptFile);
+      } catch {}
+      resolve(code === 0);
+    });
+    child.on("error", () => {
+      try {
+        unlinkSync(promptFile);
+      } catch {}
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Main distillation logic
+ */
+export async function kbDistill(options: KbDistillOptions): Promise<void> {
+  const { dataDir, backfill, dryRun } = options;
+  const dbPath = join(dataDir, "state.db");
+  const groupsDir = join(dataDir, "groups");
+
+  if (!existsSync(dbPath)) {
+    logger.error("Database not found", { dbPath });
+    process.exit(1);
+  }
+
+  const db = new Database(dbPath, { readonly: true });
+
+  // Get all groups
+  const groups = db
+    .query("SELECT DISTINCT group_id as groupId FROM messages")
+    .all() as { groupId: string }[];
+
+  logger.info("KB distill starting", { groups: groups.length, backfill });
+
+  for (const { groupId } of groups) {
+    // Derive workspace path from group ID
+    const workspaceName = groupId
+      .replace(/:/g, "_")
+      .replace(/@/g, "_")
+      .replace(/\./g, "_");
+    const groupWorkspace = join(groupsDir, workspaceName);
+
+    if (!existsSync(groupWorkspace)) {
+      logger.debug("Skipping group - workspace not found", { groupId });
+      continue;
+    }
+
+    // Export messages to JSONL files, get changed dates
+    const changed = exportMessages(db, groupId, groupWorkspace);
+
+    // Determine which dates to distill
+    const dates = backfill
+      ? [...changed].sort()
+      : changed.has(todayDate())
+        ? [todayDate()]
+        : [];
+
+    if (dates.length === 0) {
+      logger.debug("No changes to distill", { groupId });
+      continue;
+    }
+
+    logger.info("Distilling group", { groupId, dates });
+
+    // Run distiller on changed dates
+    for (const date of dates) {
+      const dateFile = getDateFile(getMessagesDir(groupWorkspace), date);
+
+      if (dryRun) {
+        logger.info("Dry run - would process", { dateFile });
+        continue;
+      }
+
+      const success = await runDistiller(groupWorkspace, dateFile);
+      if (success) {
+        logger.info("Distillation complete", { groupId, date });
+      } else {
+        logger.error("Distillation failed", { groupId, date });
+      }
+    }
+  }
+
+  db.close();
+}

--- a/src/cli/mercury.ts
+++ b/src/cli/mercury.ts
@@ -13,6 +13,7 @@ import {
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
+import { kbDistill } from "./kb-distill.js";
 import { authenticate } from "./whatsapp-auth.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -350,6 +351,30 @@ authCommand
       console.error("Authentication failed:", message);
       process.exit(1);
     }
+  });
+
+// KB Distillation command
+program
+  .command("kb-distill")
+  .description("Export messages and run kb-distiller")
+  .option("--backfill", "Process all historical messages, not just today")
+  .option("--dry-run", "Show what would be done without running distiller")
+  .action(async (options: { backfill?: boolean; dryRun?: boolean }) => {
+    const envPath = join(CWD, ".env");
+    let dataDir = ".mercury";
+
+    if (existsSync(envPath)) {
+      const envVars = loadEnvFile(envPath);
+      if (envVars.MERCURY_DATA_DIR) {
+        dataDir = envVars.MERCURY_DATA_DIR;
+      }
+    }
+
+    await kbDistill({
+      dataDir: join(CWD, dataDir),
+      backfill: options.backfill,
+      dryRun: options.dryRun,
+    });
   });
 
 program.parse();

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,14 @@ const schema = z.object({
 
   // ─── Permissions ────────────────────────────────────────────────────
   admins: z.string().default(""),
+
+  // ─── KB Distillation ────────────────────────────────────────────────
+  kbDistillIntervalMs: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(24 * 60 * 60 * 1000)
+    .default(0), // 0 = disabled
 });
 
 export type AppConfig = z.infer<typeof schema> & {
@@ -115,6 +123,9 @@ export function loadConfig(): AppConfig {
 
     // Permissions
     admins: process.env.MERCURY_ADMINS,
+
+    // KB Distillation
+    kbDistillIntervalMs: process.env.MERCURY_KB_DISTILL_INTERVAL_MS,
   });
 
   const dataDir = base.dataDir;


### PR DESCRIPTION
## Summary

Adds a KB distillation system that extracts lasting knowledge from group conversations and saves to Obsidian-compatible vaults.

## Changes

- **`mercury kb-distill` CLI** - Export messages and run distiller
- **Message export** - Daily JSONL files in `.messages/YYYY-MM-DD.jsonl`
- **Change detection** - MD5 hash comparison, only distill when content changed
- **Scheduled runs** - `MERCURY_KB_DISTILL_INTERVAL_MS` config option
- **Embedded agent** - kb-distiller prompt embedded in source, no external files

## What gets extracted

- **People** - Expertise, positions, resources shared
- **Resources** - Tools, repos, articles with context
- **Group knowledge** - Decisions and conclusions

## Usage

```bash
# Manual run
mercury kb-distill              # Today's changes
mercury kb-distill --backfill   # All historical changes

# Scheduled (env)
MERCURY_KB_DISTILL_INTERVAL_MS=3600000  # hourly
```

## Docs

See `docs/kb-distillation.md`

Closes #44