### PR TITLE
fix: use docker kill for reliable container termination

### DIFF
--- a/src/agent/container-runner.ts
+++ b/src/agent/container-runner.ts
@@ -95,7 +95,7 @@ export class AgentContainerRunner {
       try {
         execSync(`docker kill ${containerName}`, { timeout: 5000 });
       } catch {
-        // Container may have already exited, fall back to process signal
+        // docker kill can fail (container exited, daemon issues, etc.) — fall back to process signal
         proc.kill("SIGKILL");
       }
     }
@@ -119,7 +119,7 @@ export class AgentContainerRunner {
     try {
       execSync(`docker kill ${entry.containerName}`, { timeout: 5000 });
     } catch {
-      // Container may have already exited, fall back to process signal
+      // docker kill can fail (container exited, daemon issues, etc.) — fall back to process signal
       entry.proc.kill("SIGKILL");
     }
     return true;


### PR DESCRIPTION
## Summary

Fixes the stop command not immediately stopping containers.

## Problem

The `abort()` function was sending `SIGTERM` to the `docker run` process, which doesn't reliably terminate the Docker container. The timeout handler already used `docker kill` which works correctly.

Evidence from logs showed container running 1.5+ minutes after "Stopped." was returned.

## Solution

- Store `containerName` alongside `proc` in `runningByGroup` map
- `abort()` now uses `docker kill ${containerName}` (same as timeout handler)
- `killAll()` updated similarly for consistency
- Falls back to `proc.kill('SIGKILL')` if container already exited

## Testing

- TypeScript typechecks pass
- All 244 existing tests pass
- Uses same pattern as the working timeout handler

Closes #50