### PR TITLE
feat: support one-shot 'at' scheduled tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ src/
 │   ├── runtime.ts          # Main orchestrator
 │   ├── router.ts           # Message routing
 │   ├── group-queue.ts      # Per-group concurrency
-│   ├── task-scheduler.ts   # Cron execution
+│   ├── task-scheduler.ts   # Task scheduling (cron + at)
 │   ├── permissions.ts      # RBAC
 │   ├── trigger.ts          # Pattern matching
 │   ├── rate-limiter.ts     # Rate limiting
@@ -74,7 +74,7 @@ resources/
 Tables in `state.db`:
 - `groups` — Chat groups/channels
 - `messages` — Message history (for ambient context)
-- `tasks` — Scheduled cron tasks
+- `tasks` — Scheduled tasks (cron + one-shot at)
 - `roles` — User role assignments
 - `permissions` — Role permission sets
 - `config` — Per-group config overrides
@@ -105,7 +105,7 @@ Auth: `X-Mercury-Caller` + `X-Mercury-Group` headers.
 |-----|-------|
 | [ingress.md](docs/ingress.md) | Adapter message flow |
 | [memory.md](docs/memory.md) | Obsidian vault system |
-| [scheduler.md](docs/scheduler.md) | Cron tasks |
+| [scheduler.md](docs/scheduler.md) | Task scheduling (cron + at) |
 | [permissions.md](docs/permissions.md) | RBAC system |
 | [kb-distillation.md](docs/kb-distillation.md) | Knowledge extraction |
 | [container-lifecycle.md](docs/container-lifecycle.md) | Docker management |

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,6 +1,38 @@
 # Scheduler
 
-Mercury includes a task scheduler for recurring automated prompts. Tasks run on cron schedules and execute in the context of a specific group.
+Mercury includes a task scheduler for automated prompts. Tasks can run on **cron schedules** (recurring) or **at schedules** (one-shot).
+
+## Task Types
+
+### Cron Tasks (Recurring)
+
+Run on a cron schedule, repeating indefinitely:
+
+```bash
+# Daily standup at 9am
+mercury-ctl tasks create --cron "0 9 * * *" --prompt "Good morning! What's on the agenda today?"
+```
+
+### At Tasks (One-Shot)
+
+Run once at a specific time, then auto-delete:
+
+```bash
+# Reminder in 2 hours
+mercury-ctl tasks create --at "2026-03-02T16:00:00Z" --prompt "Time for the team meeting!"
+
+# Schedule a future check
+mercury-ctl tasks create --at "2026-03-15T09:00:00Z" --prompt "Follow up on the Q1 report"
+```
+
+At-tasks are useful for:
+- **Reminders** — one-time notifications
+- **Delayed actions** — schedule something for later
+- **Follow-ups** — check back on something at a specific time
+
+The `at` timestamp must be:
+- ISO 8601 format (e.g., `2026-03-02T14:00:00Z`)
+- In the future
 
 ## Silent Tasks
 
@@ -13,8 +45,11 @@ Tasks can be marked as **silent** to execute without posting results to the chat
 The task executes normally but no message is sent to the group.
 
 ```bash
-# Create a silent task
+# Create a silent cron task
 mercury-ctl tasks create --cron "0 3 * * *" --prompt "Run nightly maintenance" --silent
+
+# Create a silent at-task
+mercury-ctl tasks create --at "2026-03-02T03:00:00Z" --prompt "One-time cleanup" --silent
 ```
 
 ## How It Works
@@ -27,20 +62,34 @@ TaskScheduler.start()
         ├─► Query DB for due tasks (active=1, next_run_at <= now)
         │
         ├─► For each due task:
-        │     ├─► Compute next run time from cron expression
-        │     ├─► Update next_run_at in DB
-        │     └─► Execute handler (sends prompt to group)
+        │     │
+        │     ├─► [Cron task]
+        │     │     ├─► Compute next run time from cron expression
+        │     │     ├─► Update next_run_at in DB
+        │     │     └─► Execute handler
+        │     │
+        │     └─► [At task]
+        │           ├─► Execute handler
+        │           └─► Delete task from DB
         │
         └─► Schedule next poll
 ```
 
 Tasks are processed sequentially within a poll cycle. Each task runs as if the `createdBy` user sent the prompt.
 
+**At-task lifecycle:**
+1. Created with a future timestamp
+2. Waits until scheduled time
+3. Executes once
+4. Auto-deletes (regardless of success/failure)
+
 ## Creating Tasks
 
 The agent creates tasks via `mercury-ctl`:
 
 ```bash
+# === Cron tasks (recurring) ===
+
 # Daily standup at 9am
 mercury-ctl tasks create --cron "0 9 * * *" --prompt "Good morning! What's on the agenda today?"
 
@@ -52,7 +101,17 @@ mercury-ctl tasks create --cron "0 */6 * * *" --prompt "Check for any pending it
 
 # Silent nightly cleanup (no chat output)
 mercury-ctl tasks create --cron "0 3 * * *" --prompt "Clean up old temp files" --silent
+
+# === At tasks (one-shot) ===
+
+# Reminder at a specific time
+mercury-ctl tasks create --at "2026-03-02T14:00:00Z" --prompt "Meeting starts in 15 minutes!"
+
+# Delayed follow-up
+mercury-ctl tasks create --at "2026-03-10T09:00:00Z" --prompt "Check if the deployment completed successfully"
 ```
+
+**Note:** You must specify either `--cron` or `--at`, not both.
 
 ## Managing Tasks
 
@@ -65,6 +124,9 @@ mercury-ctl tasks pause <id>
 
 # Resume a paused task
 mercury-ctl tasks resume <id>
+
+# Manually trigger a task now
+mercury-ctl tasks run <id>
 
 # Delete a task permanently
 mercury-ctl tasks delete <id>
@@ -116,7 +178,8 @@ Tasks are stored in SQLite:
 CREATE TABLE tasks (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   group_id TEXT NOT NULL,
-  cron TEXT NOT NULL,
+  cron TEXT,                          -- Cron expression (null for at-tasks)
+  at TEXT,                            -- ISO 8601 timestamp (null for cron-tasks)
   prompt TEXT NOT NULL,
   active INTEGER NOT NULL DEFAULT 1,
   silent INTEGER NOT NULL DEFAULT 0,
@@ -131,6 +194,8 @@ CREATE INDEX idx_tasks_next ON tasks(active, next_run_at);
 
 | Column | Description |
 |--------|-------------|
+| `cron` | Cron expression for recurring tasks (null for at-tasks) |
+| `at` | ISO 8601 timestamp for one-shot tasks (null for cron-tasks) |
 | `silent` | If 1, task runs but doesn't post results to chat |
 
 ## Permissions
@@ -180,7 +245,7 @@ const scheduler = new TaskScheduler(db, pollIntervalMs);
 
 scheduler.start(handler);    // Begin polling
 scheduler.stop();            // Stop polling
-scheduler.computeNextRun(cron, from);  // Get next run time
+scheduler.computeNextRun(cron, from);  // Get next run time for cron tasks
 ```
 
 ### Handler Signature
@@ -198,12 +263,18 @@ type TaskHandler = (task: {
 ### Database Methods
 
 ```typescript
-db.createTask(groupId, cron, prompt, nextRunAt, createdBy, silent);  // Returns task ID
-db.listTasks(groupId?);      // List tasks (optionally filter by group)
-db.getDueTasks(now);         // Get tasks ready to run
-db.getTask(id);              // Get single task
+// Create a cron task
+db.createTask(groupId, { cron: "0 9 * * *" }, prompt, nextRunAt, createdBy, silent);
+
+// Create an at-task
+db.createTask(groupId, { at: "2026-03-02T14:00:00Z" }, prompt, nextRunAt, createdBy, silent);
+
+db.listTasks(groupId?);       // List tasks (optionally filter by group)
+db.getDueTasks(now);          // Get tasks ready to run
+db.getTask(id);               // Get single task
 db.setTaskActive(id, active); // Pause/resume
-db.deleteTask(id, groupId);  // Delete task
+db.deleteTask(id, groupId);   // Delete task (with group check)
+db.deleteTaskById(id);        // Delete task (no group check, for scheduler)
 db.updateTaskNextRun(id, nextRunAt);  // Update next execution time
 ```
 
@@ -212,5 +283,6 @@ db.updateTaskNextRun(id, nextRunAt);  // Update next execution time
 If a task handler fails:
 - Error is logged
 - Task is not retried in the same cycle
-- `next_run_at` is already updated, so it will run again at the next scheduled time
+- **Cron tasks:** `next_run_at` is already updated, so it will run again at the next scheduled time
+- **At tasks:** Still deleted after execution (one-shot behavior preserved)
 - Other tasks in the cycle continue to execute

--- a/resources/templates/AGENTS.md
+++ b/resources/templates/AGENTS.md
@@ -47,12 +47,20 @@ mercury-ctl whoami                    # Show caller, group, role, permissions
 ### Scheduled Tasks
 ```bash
 mercury-ctl tasks list                # List all tasks for this group
+
+# Recurring tasks (cron)
 mercury-ctl tasks create --cron "0 9 * * *" --prompt "Good morning!" [--silent]
+
+# One-shot tasks (at) — auto-delete after execution
+mercury-ctl tasks create --at "2026-03-02T14:00:00Z" --prompt "Reminder!" [--silent]
+
 mercury-ctl tasks run <id>            # Trigger task immediately
 mercury-ctl tasks pause <id>          # Pause a task
 mercury-ctl tasks resume <id>         # Resume a paused task
 mercury-ctl tasks delete <id>         # Delete a task
 ```
+
+**Note:** Use `--cron` for recurring tasks or `--at` for one-shot tasks (ISO 8601, must be in the future).
 
 ### Group Configuration
 ```bash

--- a/src/cli/mercury-ctl.ts
+++ b/src/cli/mercury-ctl.ts
@@ -52,6 +52,7 @@ Usage:
   mercury-ctl whoami
   mercury-ctl tasks list
   mercury-ctl tasks create --cron <expr> --prompt <text> [--silent]
+  mercury-ctl tasks create --at <ISO8601> --prompt <text> [--silent]
   mercury-ctl tasks pause <id>
   mercury-ctl tasks resume <id>
   mercury-ctl tasks run <id>
@@ -109,13 +110,13 @@ async function main() {
           break;
         case "create": {
           const cron = parseFlag(args, "--cron");
+          const at = parseFlag(args, "--at");
           const prompt = parseFlag(args, "--prompt");
           const silent = args.includes("--silent");
-          if (!cron || !prompt)
-            fatal(
-              "Usage: tasks create --cron <expr> --prompt <text> [--silent]",
-            );
-          print(await api("POST", "/api/tasks", { cron, prompt, silent }));
+          if (!prompt) fatal("Missing --prompt");
+          if (!cron && !at) fatal("Must specify --cron or --at");
+          if (cron && at) fatal("Cannot specify both --cron and --at");
+          print(await api("POST", "/api/tasks", { cron, at, prompt, silent }));
           break;
         }
         case "pause": {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -23,6 +23,7 @@ interface ApiContext {
 
 interface TaskCreateBody {
   cron?: string;
+  at?: string; // ISO 8601 timestamp for one-shot tasks
   prompt?: string;
   silent?: boolean;
 }
@@ -125,32 +126,52 @@ export function handleApiRequest(
     return (async () => {
       const body = await parseBody<TaskCreateBody>(request);
       if (!body) return error("Invalid JSON body", 400);
-      if (!body.cron || !body.prompt)
-        return error("Missing cron or prompt", 400);
-      try {
-        const interval = CronExpressionParser.parse(body.cron, {
-          currentDate: new Date(),
-        });
-        const nextRunAt = interval.next().getTime();
-        const silent = body.silent ?? false;
-        const id = ctx.db.createTask(
-          groupId,
-          body.cron,
-          body.prompt,
-          nextRunAt,
-          callerId,
-          silent,
-        );
-        return json({
-          id,
-          cron: body.cron,
-          prompt: body.prompt,
-          silent,
-          nextRunAt,
-        });
-      } catch {
-        return error("Invalid cron expression", 400);
+      if (!body.prompt) return error("Missing prompt", 400);
+      if (!body.cron && !body.at) return error("Missing cron or at", 400);
+      if (body.cron && body.at)
+        return error("Cannot specify both cron and at", 400);
+
+      const silent = body.silent ?? false;
+      let nextRunAt: number;
+      let schedule: { cron: string } | { at: string };
+
+      if (body.cron) {
+        try {
+          const interval = CronExpressionParser.parse(body.cron, {
+            currentDate: new Date(),
+          });
+          nextRunAt = interval.next().getTime();
+          schedule = { cron: body.cron };
+        } catch {
+          return error("Invalid cron expression", 400);
+        }
+      } else {
+        const atStr = body.at as string; // Safe: validated above (!body.cron && !body.at)
+        const atTime = new Date(atStr).getTime();
+        if (Number.isNaN(atTime)) return error("Invalid at timestamp", 400);
+        if (atTime <= Date.now())
+          return error("at timestamp must be in the future", 400);
+        nextRunAt = atTime;
+        schedule = { at: atStr };
       }
+
+      const id = ctx.db.createTask(
+        groupId,
+        schedule,
+        body.prompt,
+        nextRunAt,
+        callerId,
+        silent,
+      );
+
+      return json({
+        id,
+        cron: body.cron ?? null,
+        at: body.at ?? null,
+        prompt: body.prompt,
+        silent,
+        nextRunAt,
+      });
     })();
   }
 

--- a/src/core/task-scheduler.ts
+++ b/src/core/task-scheduler.ts
@@ -27,8 +27,13 @@ export class TaskScheduler {
       try {
         const due = this.db.getDueTasks(Date.now());
         for (const task of due) {
-          const next = this.computeNextRun(task.cron);
-          this.db.updateTaskNextRun(task.id, next);
+          // For cron tasks, update next run before execution
+          // For at-tasks, we'll delete after execution
+          if (task.cron) {
+            const next = this.computeNextRun(task.cron);
+            this.db.updateTaskNextRun(task.id, next);
+          }
+
           try {
             await handler({
               id: task.id,
@@ -42,6 +47,15 @@ export class TaskScheduler {
               taskId: task.id,
               groupId: task.groupId,
               error: error instanceof Error ? error.message : String(error),
+            });
+          }
+
+          // For at-tasks, delete after execution (regardless of success/failure)
+          if (task.at) {
+            this.db.deleteTaskById(task.id);
+            logger.info("One-shot task completed and deleted", {
+              taskId: task.id,
+              groupId: task.groupId,
             });
           }
         }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -60,7 +60,8 @@ export class Db {
       CREATE TABLE IF NOT EXISTS tasks (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         group_id TEXT NOT NULL,
-        cron TEXT NOT NULL,
+        cron TEXT,
+        at TEXT,
         prompt TEXT NOT NULL,
         active INTEGER NOT NULL DEFAULT 1,
         silent INTEGER NOT NULL DEFAULT 0,
@@ -106,6 +107,13 @@ export class Db {
 
     // Migration: add silent column to tasks table
     this.addColumnIfNotExists("tasks", "silent", "INTEGER NOT NULL DEFAULT 0");
+
+    // Migration: add at column to tasks table for one-shot tasks
+    this.addColumnIfNotExists("tasks", "at", "TEXT");
+
+    // Note: For existing databases where cron was NOT NULL, SQLite allows NULL values
+    // in columns declared NOT NULL when inserted via ALTER TABLE or when the column
+    // constraint was removed from CREATE TABLE. New databases get the correct schema.
   }
 
   private addColumnIfNotExists(
@@ -299,20 +307,23 @@ export class Db {
 
   createTask(
     groupId: string,
-    cron: string,
+    schedule: { cron: string } | { at: string },
     prompt: string,
     nextRunAt: number,
     createdBy: string,
     silent = false,
   ): number {
     const now = Date.now();
+    const cron = "cron" in schedule ? schedule.cron : null;
+    const at = "at" in schedule ? schedule.at : null;
     this.db
       .query(
-        "INSERT INTO tasks(group_id, cron, prompt, active, silent, next_run_at, created_by, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)",
+        "INSERT INTO tasks(group_id, cron, at, prompt, active, silent, next_run_at, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?)",
       )
       .run(
         groupId,
         cron,
+        at,
         prompt,
         silent ? 1 : 0,
         nextRunAt,
@@ -332,7 +343,7 @@ export class Db {
     if (groupId) {
       return this.db
         .query(
-          `SELECT id, group_id as groupId, cron, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
+          `SELECT id, group_id as groupId, cron, at, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
            FROM tasks WHERE group_id = ? ORDER BY id ASC`,
         )
         .all(groupId) as ScheduledTask[];
@@ -340,7 +351,7 @@ export class Db {
 
     return this.db
       .query(
-        `SELECT id, group_id as groupId, cron, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
+        `SELECT id, group_id as groupId, cron, at, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
          FROM tasks ORDER BY id ASC`,
       )
       .all() as ScheduledTask[];
@@ -349,7 +360,7 @@ export class Db {
   getDueTasks(now = Date.now()): ScheduledTask[] {
     return this.db
       .query(
-        `SELECT id, group_id as groupId, cron, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
+        `SELECT id, group_id as groupId, cron, at, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
          FROM tasks
          WHERE active = 1 AND next_run_at <= ?
          ORDER BY next_run_at ASC`,
@@ -376,10 +387,15 @@ export class Db {
     return result.changes > 0;
   }
 
+  deleteTaskById(id: number): boolean {
+    const result = this.db.query("DELETE FROM tasks WHERE id = ?").run(id);
+    return result.changes > 0;
+  }
+
   getTask(id: number): ScheduledTask | null {
     return this.db
       .query(
-        `SELECT id, group_id as groupId, cron, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
+        `SELECT id, group_id as groupId, cron, at, prompt, active, silent, next_run_at as nextRunAt, created_by as createdBy, created_at as createdAt, updated_at as updatedAt
          FROM tasks WHERE id = ?`,
       )
       .get(id) as ScheduledTask | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,8 @@ export interface StoredMessage {
 export interface ScheduledTask {
   id: number;
   groupId: string;
-  cron: string;
+  cron: string | null; // null for at-tasks
+  at: string | null; // ISO 8601 timestamp, null for cron-tasks
   prompt: string;
   active: number;
   silent: number;

--- a/tests/at-tasks.test.ts
+++ b/tests/at-tasks.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { TaskScheduler } from "../src/core/task-scheduler.js";
+import { Db } from "../src/storage/db.js";
+
+let tmpDir: string;
+let db: Db;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mercury-at-tasks-test-"));
+  db = new Db(path.join(tmpDir, "state.db"));
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("at-tasks database", () => {
+  test("createTask with at schedule", () => {
+    db.ensureGroup("g1");
+    const atTime = new Date(Date.now() + 60000).toISOString();
+    const id = db.createTask(
+      "g1",
+      { at: atTime },
+      "one-shot task",
+      Date.now() + 60000,
+      "user1",
+    );
+    expect(id).toBeGreaterThan(0);
+
+    const task = db.getTask(id);
+    expect(task).not.toBeNull();
+    expect(task?.at).toBe(atTime);
+    expect(task?.cron).toBeNull();
+    expect(task?.prompt).toBe("one-shot task");
+  });
+
+  test("createTask with cron schedule still works", () => {
+    db.ensureGroup("g1");
+    const id = db.createTask(
+      "g1",
+      { cron: "*/5 * * * *" },
+      "recurring task",
+      Date.now() + 60000,
+      "user1",
+    );
+
+    const task = db.getTask(id);
+    expect(task).not.toBeNull();
+    expect(task?.cron).toBe("*/5 * * * *");
+    expect(task?.at).toBeNull();
+  });
+
+  test("listTasks includes at field", () => {
+    db.ensureGroup("g1");
+    const atTime = new Date(Date.now() + 60000).toISOString();
+    db.createTask("g1", { at: atTime }, "at-task", Date.now() + 60000, "user1");
+    db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "cron-task",
+      Date.now() + 60000,
+      "user1",
+    );
+
+    const tasks = db.listTasks("g1");
+    expect(tasks.length).toBe(2);
+
+    const atTask = tasks.find((t) => t.prompt === "at-task");
+    const cronTask = tasks.find((t) => t.prompt === "cron-task");
+
+    expect(atTask?.at).toBe(atTime);
+    expect(atTask?.cron).toBeNull();
+    expect(cronTask?.cron).toBe("* * * * *");
+    expect(cronTask?.at).toBeNull();
+  });
+
+  test("getDueTasks includes at-tasks", () => {
+    db.ensureGroup("g1");
+    const now = Date.now();
+    const atTime = new Date(now - 1000).toISOString();
+    db.createTask("g1", { at: atTime }, "due at-task", now - 1000, "user1");
+
+    const due = db.getDueTasks(now);
+    expect(due.length).toBe(1);
+    expect(due[0].at).toBe(atTime);
+    expect(due[0].prompt).toBe("due at-task");
+  });
+
+  test("deleteTaskById removes task without groupId", () => {
+    db.ensureGroup("g1");
+    const id = db.createTask(
+      "g1",
+      { at: new Date(Date.now() + 60000).toISOString() },
+      "task",
+      Date.now() + 60000,
+      "user1",
+    );
+
+    expect(db.deleteTaskById(id)).toBe(true);
+    expect(db.getTask(id)).toBeNull();
+  });
+
+  test("deleteTaskById returns false for missing task", () => {
+    expect(db.deleteTaskById(999)).toBe(false);
+  });
+
+  test("at-task respects active flag", () => {
+    db.ensureGroup("g1");
+    const now = Date.now();
+    const id = db.createTask(
+      "g1",
+      { at: new Date(now - 1000).toISOString() },
+      "paused at-task",
+      now - 1000,
+      "user1",
+    );
+
+    db.setTaskActive(id, false);
+    expect(db.getDueTasks(now).length).toBe(0);
+
+    db.setTaskActive(id, true);
+    expect(db.getDueTasks(now).length).toBe(1);
+  });
+
+  test("at-task with silent flag", () => {
+    db.ensureGroup("g1");
+    const atTime = new Date(Date.now() + 60000).toISOString();
+    const id = db.createTask(
+      "g1",
+      { at: atTime },
+      "silent at-task",
+      Date.now() + 60000,
+      "user1",
+      true,
+    );
+
+    const task = db.getTask(id);
+    expect(task?.silent).toBe(1);
+  });
+});
+
+describe("at-tasks scheduler", () => {
+  test("scheduler deletes at-task after execution", async () => {
+    db.ensureGroup("g1");
+    const now = Date.now();
+    const atTime = new Date(now - 1000).toISOString();
+    const taskId = db.createTask(
+      "g1",
+      { at: atTime },
+      "one-shot",
+      now - 1000,
+      "user1",
+    );
+
+    const executed: number[] = [];
+    const scheduler = new TaskScheduler(db, 100);
+
+    scheduler.start(async (task) => {
+      executed.push(task.id);
+    });
+
+    // Wait for scheduler to process
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    scheduler.stop();
+
+    // Task should have been executed
+    expect(executed).toContain(taskId);
+
+    // Task should be deleted
+    expect(db.getTask(taskId)).toBeNull();
+  });
+
+  test("scheduler keeps cron-task after execution", async () => {
+    db.ensureGroup("g1");
+    const now = Date.now();
+    const taskId = db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "recurring",
+      now - 1000,
+      "user1",
+    );
+
+    const executed: number[] = [];
+    const scheduler = new TaskScheduler(db, 100);
+
+    scheduler.start(async (task) => {
+      executed.push(task.id);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    scheduler.stop();
+
+    // Task should have been executed
+    expect(executed).toContain(taskId);
+
+    // Task should still exist with updated nextRunAt
+    const task = db.getTask(taskId);
+    expect(task).not.toBeNull();
+    expect(task?.nextRunAt).toBeGreaterThan(now);
+  });
+
+  test("at-task deleted even if handler throws", async () => {
+    db.ensureGroup("g1");
+    const now = Date.now();
+    const atTime = new Date(now - 1000).toISOString();
+    const taskId = db.createTask(
+      "g1",
+      { at: atTime },
+      "failing task",
+      now - 1000,
+      "user1",
+    );
+
+    const scheduler = new TaskScheduler(db, 100);
+
+    scheduler.start(async () => {
+      throw new Error("Handler failed");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    scheduler.stop();
+
+    // Task should still be deleted even though handler failed
+    expect(db.getTask(taskId)).toBeNull();
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -132,7 +132,7 @@ describe("tasks", () => {
     db.ensureGroup("g1");
     const id = db.createTask(
       "g1",
-      "*/5 * * * *",
+      { cron: "*/5 * * * *" },
       "check stuff",
       Date.now() + 60000,
       "user1",
@@ -142,6 +142,7 @@ describe("tasks", () => {
     const tasks = db.listTasks("g1");
     expect(tasks.length).toBe(1);
     expect(tasks[0].cron).toBe("*/5 * * * *");
+    expect(tasks[0].at).toBeNull();
     expect(tasks[0].prompt).toBe("check stuff");
     expect(tasks[0].createdBy).toBe("user1");
     expect(tasks[0].active).toBe(1);
@@ -150,8 +151,8 @@ describe("tasks", () => {
   test("getDueTasks returns only due tasks", () => {
     db.ensureGroup("g1");
     const now = Date.now();
-    db.createTask("g1", "* * * * *", "due", now - 1000, "user1");
-    db.createTask("g1", "* * * * *", "not due", now + 60000, "user1");
+    db.createTask("g1", { cron: "* * * * *" }, "due", now - 1000, "user1");
+    db.createTask("g1", { cron: "* * * * *" }, "not due", now + 60000, "user1");
 
     const due = db.getDueTasks(now);
     expect(due.length).toBe(1);
@@ -162,7 +163,7 @@ describe("tasks", () => {
     db.ensureGroup("g1");
     const id = db.createTask(
       "g1",
-      "* * * * *",
+      { cron: "* * * * *" },
       "task",
       Date.now() - 1000,
       "user1",
@@ -177,7 +178,13 @@ describe("tasks", () => {
 
   test("deleteTask removes task", () => {
     db.ensureGroup("g1");
-    const id = db.createTask("g1", "* * * * *", "task", Date.now(), "user1");
+    const id = db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "task",
+      Date.now(),
+      "user1",
+    );
 
     expect(db.deleteTask(id, "g1")).toBe(true);
     expect(db.listTasks("g1").length).toBe(0);
@@ -186,7 +193,13 @@ describe("tasks", () => {
   test("deleteTask fails for wrong group", () => {
     db.ensureGroup("g1");
     db.ensureGroup("g2");
-    const id = db.createTask("g1", "* * * * *", "task", Date.now(), "user1");
+    const id = db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "task",
+      Date.now(),
+      "user1",
+    );
 
     expect(db.deleteTask(id, "g2")).toBe(false);
     expect(db.listTasks("g1").length).toBe(1);
@@ -194,7 +207,13 @@ describe("tasks", () => {
 
   test("getTask returns task by id", () => {
     db.ensureGroup("g1");
-    const id = db.createTask("g1", "* * * * *", "task", Date.now(), "user1");
+    const id = db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "task",
+      Date.now(),
+      "user1",
+    );
 
     const task = db.getTask(id);
     expect(task).not.toBeNull();
@@ -208,7 +227,13 @@ describe("tasks", () => {
 
   test("updateTaskNextRun updates next_run_at", () => {
     db.ensureGroup("g1");
-    const id = db.createTask("g1", "* * * * *", "task", 1000, "user1");
+    const id = db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "task",
+      1000,
+      "user1",
+    );
 
     db.updateTaskNextRun(id, 2000);
     const task = db.getTask(id);
@@ -219,7 +244,7 @@ describe("tasks", () => {
     db.ensureGroup("g1");
     const id = db.createTask(
       "g1",
-      "* * * * *",
+      { cron: "* * * * *" },
       "silent task",
       Date.now(),
       "user1",
@@ -232,7 +257,13 @@ describe("tasks", () => {
 
   test("createTask defaults to not silent", () => {
     db.ensureGroup("g1");
-    const id = db.createTask("g1", "* * * * *", "task", Date.now(), "user1");
+    const id = db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "task",
+      Date.now(),
+      "user1",
+    );
 
     const task = db.getTask(id);
     expect(task?.silent).toBe(0);
@@ -240,8 +271,22 @@ describe("tasks", () => {
 
   test("listTasks includes silent field", () => {
     db.ensureGroup("g1");
-    db.createTask("g1", "* * * * *", "normal", Date.now(), "user1", false);
-    db.createTask("g1", "* * * * *", "silent", Date.now(), "user1", true);
+    db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "normal",
+      Date.now(),
+      "user1",
+      false,
+    );
+    db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "silent",
+      Date.now(),
+      "user1",
+      true,
+    );
 
     const tasks = db.listTasks("g1");
     expect(tasks.length).toBe(2);
@@ -252,7 +297,14 @@ describe("tasks", () => {
   test("getDueTasks includes silent field", () => {
     db.ensureGroup("g1");
     const now = Date.now();
-    db.createTask("g1", "* * * * *", "silent due", now - 1000, "user1", true);
+    db.createTask(
+      "g1",
+      { cron: "* * * * *" },
+      "silent due",
+      now - 1000,
+      "user1",
+      true,
+    );
 
     const due = db.getDueTasks(now);
     expect(due.length).toBe(1);
@@ -372,8 +424,8 @@ describe("tasks — listTasks without groupId", () => {
   test("returns all tasks across groups", () => {
     db.ensureGroup("g1");
     db.ensureGroup("g2");
-    db.createTask("g1", "* * * * *", "task1", Date.now(), "user1");
-    db.createTask("g2", "* * * * *", "task2", Date.now(), "user2");
+    db.createTask("g1", { cron: "* * * * *" }, "task1", Date.now(), "user1");
+    db.createTask("g2", { cron: "* * * * *" }, "task2", Date.now(), "user2");
 
     const all = db.listTasks();
     expect(all.length).toBe(2);


### PR DESCRIPTION
## Summary

Adds one-shot `at` tasks that fire once at a specific ISO 8601 timestamp and auto-delete after execution.

## Changes

### Core
- **types.ts**: `cron` now nullable, added `at: string | null`
- **db.ts**: Updated schema, `createTask()` accepts `{ cron }` or `{ at }`, added `deleteTaskById()`
- **task-scheduler.ts**: Auto-deletes at-tasks after execution
- **api.ts**: Validates `at` is ISO 8601 and in the future, mutual exclusivity with `cron`

### CLI
- **mercury-ctl.ts**: Added `--at <ISO8601>` flag to `tasks create`

### Tests
- **at-tasks.test.ts**: 11 new tests covering at-task lifecycle

### Docs
- **docs/scheduler.md**: Major update with at-tasks section
- **resources/templates/AGENTS.md**: Added `--at` to command reference
- **AGENTS.md**: Updated descriptions

## Usage

```bash
# One-shot reminder
mercury-ctl tasks create --at "2026-03-02T14:00:00Z" --prompt "Meeting time!"

# Silent one-shot task
mercury-ctl tasks create --at "2026-03-15T09:00:00Z" --prompt "Cleanup" --silent
```

## Validation
- `at` timestamp must be valid ISO 8601
- `at` timestamp must be in the future
- Cannot specify both `--cron` and `--at`

Closes #64