### PR TITLE
feat: respond to replies on bot messages

### DIFF
--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -130,6 +130,19 @@ All adapters share the same trigger engine. A pre-route check runs before `handl
 
 DMs always match regardless of mode.
 
+### Reply-to-Bot
+
+Replying to a bot message triggers a response — no explicit `@mention` needed:
+
+```
+User: @Mercury what's the weather?
+Bot: It's 72°F and sunny.
+User: [replies] what about tomorrow?  ← triggers response
+Bot: Tomorrow will be 75°F.
+```
+
+This works on WhatsApp (quoted messages) and Discord (reply threads). Slack uses a different threading model where users typically `@mention` in threads, so reply detection is not implemented there.
+
 **Configuration:**
 
 ```bash

--- a/src/adapters/discord-native.ts
+++ b/src/adapters/discord-native.ts
@@ -421,12 +421,29 @@ export class DiscordNativeAdapter
       msg.mentions.users.has(this.client.user?.id || "") ||
       msg.content.includes(`<@${this.client.user?.id}>`);
 
+    // Check if this is a reply to one of our messages
+    let isReplyToBot = false;
+    if (msg.reference?.messageId && this.client.user?.id) {
+      try {
+        const channel = msg.channel;
+        if ("messages" in channel) {
+          const repliedTo = await channel.messages.fetch(
+            msg.reference.messageId,
+          );
+          isReplyToBot = repliedTo.author.id === this.client.user.id;
+        }
+      } catch {
+        // Referenced message may be deleted or inaccessible
+      }
+    }
+
     logger.debug("Discord native inbound", {
       guildId,
       channelId,
       threadId,
       isDM,
       isMention,
+      isReplyToBot,
       preview: text.slice(0, 80),
     });
 
@@ -447,6 +464,8 @@ export class DiscordNativeAdapter
       metadata: {
         dateSent: msg.createdAt,
         edited: msg.editedAt !== null,
+        // Store reply flag in metadata for downstream consumers
+        ...({ isReplyToBot } as Record<string, unknown>),
       },
       attachments: msg.attachments.map((a) => ({
         type: this.getAttachmentType(a.contentType),

--- a/src/adapters/discord.ts
+++ b/src/adapters/discord.ts
@@ -87,10 +87,15 @@ export function createDiscordMessageHandler(
     const callerId = discordCallerId(message);
     const isDM = isDiscordDM(thread.id);
 
+    // Extract reply flag from message metadata (set by discord-native adapter)
+    const isReplyToBot =
+      (message.metadata as { isReplyToBot?: boolean })?.isReplyToBot ?? false;
+
     logger.debug("Discord inbound", {
       groupId,
       callerId,
       isDM,
+      isReplyToBot,
       threadId: thread.id,
       preview: text.slice(0, 120),
     });
@@ -108,7 +113,10 @@ export function createDiscordMessageHandler(
       });
       const triggerResult = matchTrigger(text, triggerConfig, isDM);
 
-      if (triggerResult.matched) {
+      // Start typing if trigger matched or reply to bot
+      const shouldStartTyping =
+        triggerResult.matched || (isReplyToBot && !isDM);
+      if (shouldStartTyping) {
         if (isNew) await thread.subscribe();
         await thread.startTyping();
       }
@@ -119,6 +127,7 @@ export function createDiscordMessageHandler(
         callerId,
         authorName: message.author.userName,
         isDM,
+        isReplyToBot,
         source: "chat-sdk",
       });
 

--- a/src/adapters/slack.ts
+++ b/src/adapters/slack.ts
@@ -88,6 +88,12 @@ export function createSlackMessageHandler(opts: SlackMessageHandlerOptions) {
     const callerId = slackCallerId(message);
     const isDM = isSlackDM(thread.id);
 
+    // Slack reply-to-bot detection is not implemented.
+    // Slack's threading model is different — users typically @ mention in threads.
+    // For thread participation detection, would need to fetch thread history.
+    // TODO: Implement basic parent-message check if needed.
+    const isReplyToBot = false;
+
     logger.debug("Slack inbound", {
       groupId,
       callerId,
@@ -120,6 +126,7 @@ export function createSlackMessageHandler(opts: SlackMessageHandlerOptions) {
         callerId,
         authorName: message.author.userName,
         isDM,
+        isReplyToBot,
         source: "chat-sdk",
       });
 

--- a/src/adapters/whatsapp.ts
+++ b/src/adapters/whatsapp.ts
@@ -493,6 +493,12 @@ export class WhatsAppBaileysAdapter
       (botJid && areJidsSameUser(jid, botJid)) ||
       (botLid && areJidsSameUser(jid, botLid));
 
+    // Check if this is a reply to one of our messages
+    const quotedParticipant = contextInfo?.participant;
+    const isReplyToBot = quotedParticipant
+      ? isBotJid(quotedParticipant)
+      : false;
+
     // Replace bot's JID mention with configured userName so trigger patterns match
     for (const jid of mentionedJids) {
       if (isBotJid(jid)) {
@@ -553,6 +559,7 @@ export class WhatsAppBaileysAdapter
       remoteJid,
       sender,
       isReply: Boolean(replyContext),
+      isReplyToBot,
       hasMedia: attachments.length > 0,
       mediaType: mediaInfo?.type,
       preview: text.slice(0, 120),
@@ -579,9 +586,9 @@ export class WhatsAppBaileysAdapter
           Number(msg.messageTimestamp ?? Date.now() / 1000) * 1000,
         ),
         edited: false,
-        // Store attachments in metadata for downstream consumers
-        // Using spread to add custom property (not in MessageMetadata type)
-        ...({ attachments } as Record<string, unknown>),
+        // Store attachments and reply flag in metadata for downstream consumers
+        // Using spread to add custom properties (not in MessageMetadata type)
+        ...({ attachments, isReplyToBot } as Record<string, unknown>),
       },
       attachments: [],
     });

--- a/src/chat-sdk.ts
+++ b/src/chat-sdk.ts
@@ -136,9 +136,13 @@ async function main() {
     // Quick trigger check before starting typing indicator
     const text = message.text.trim();
 
-    // Extract attachments from message metadata (populated by WhatsApp adapter)
-    const attachments =
-      (message.metadata as { attachments?: unknown })?.attachments ?? [];
+    // Extract attachments and reply flag from message metadata (populated by adapters)
+    const metadata = message.metadata as {
+      attachments?: unknown;
+      isReplyToBot?: boolean;
+    };
+    const attachments = metadata?.attachments ?? [];
+    const isReplyToBot = metadata?.isReplyToBot ?? false;
 
     // Allow messages with only attachments (no text)
     if (!text && (!Array.isArray(attachments) || attachments.length === 0))
@@ -154,8 +158,9 @@ async function main() {
     });
     const triggerResult = matchTrigger(text, triggerConfig, isDM);
 
-    // Only start typing if trigger matched (or DM)
-    if (triggerResult.matched) {
+    // Start typing if trigger matched, DM, or reply to bot
+    const shouldStartTyping = triggerResult.matched || (isReplyToBot && !isDM);
+    if (shouldStartTyping) {
       if (isNew) await thread.subscribe();
       await thread.startTyping();
     }
@@ -166,6 +171,7 @@ async function main() {
       callerId,
       authorName: message.author.userName,
       isDM,
+      isReplyToBot,
       source: "chat-sdk",
       attachments: Array.isArray(attachments) ? attachments : [],
     });

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -24,6 +24,7 @@ export function routeInput(input: {
   groupId: string;
   callerId: string;
   isDM: boolean;
+  isReplyToBot?: boolean;
   db: Db;
   config: AppConfig;
 }): RouteResult {
@@ -57,12 +58,16 @@ export function routeInput(input: {
     match: input.config.triggerMatch,
   });
 
-  // Match trigger
+  // Match trigger OR reply-to-bot
   const result = matchTrigger(text, triggerConfig, input.isDM);
-  if (!result.matched) return { type: "ignore" };
+  const isReplyTrigger = input.isReplyToBot && !input.isDM;
+  if (!result.matched && !isReplyTrigger) return { type: "ignore" };
+
+  // Use stripped prompt if trigger matched, otherwise full text for replies
+  const prompt = result.matched ? result.prompt : text;
 
   // Check for commands after trigger (e.g. "@Pi stop", "Pi compact")
-  const cmdWord = result.prompt.toLowerCase().trim();
+  const cmdWord = prompt.toLowerCase().trim();
   if (cmdWord in CHAT_COMMANDS) {
     return gateCommand(input.db, input.groupId, cmdWord, role, input.callerId);
   }
@@ -77,7 +82,7 @@ export function routeInput(input: {
 
   return {
     type: "assistant",
-    prompt: result.prompt,
+    prompt,
     callerId: input.callerId,
     role,
   };

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -114,6 +114,7 @@ export class MercuryCoreRuntime {
     callerId: string;
     authorName?: string;
     isDM: boolean;
+    isReplyToBot?: boolean;
     source: Exclude<InputSource, "scheduler">;
     attachments?: MessageAttachment[];
   }): Promise<RouteResult & { reply?: string }> {
@@ -122,6 +123,7 @@ export class MercuryCoreRuntime {
       groupId: input.groupId,
       callerId: input.callerId,
       isDM: input.isDM,
+      isReplyToBot: input.isReplyToBot,
       db: this.db,
       config: this.config,
     });

--- a/tests/discord-adapter.test.ts
+++ b/tests/discord-adapter.test.ts
@@ -276,6 +276,50 @@ describe("createDiscordMessageHandler", () => {
     // Group ID is now the full thread ID (including guild and sub-thread)
     expect(call.groupId).toBe("discord:111222333:444555666:999000111");
   });
+
+  test("passes isReplyToBot from metadata to handleRawInput", async () => {
+    const { handler, thread, core } = setup();
+    core.handleRawInput = mock(async () => ({
+      type: "assistant" as const,
+      prompt: "what about tomorrow?",
+      callerId: "discord:U123",
+      role: "member",
+      reply: "Tomorrow looks good!",
+    }));
+
+    // Message is a reply to bot (no trigger pattern)
+    const msg = fakeMessage({
+      text: "what about tomorrow?",
+      isReplyToBot: true,
+    });
+    await handler(thread, msg, true);
+
+    const call = (core.handleRawInput as ReturnType<typeof mock>).mock
+      .calls[0][0];
+    expect(call.isReplyToBot).toBe(true);
+    expect(call.rawText).toBe("what about tomorrow?");
+  });
+
+  test("starts typing for reply-to-bot without explicit trigger", async () => {
+    const { handler, thread, core } = setup();
+    core.handleRawInput = mock(async () => ({
+      type: "assistant" as const,
+      prompt: "followup question",
+      callerId: "discord:U123",
+      role: "member",
+      reply: "Here's your answer!",
+    }));
+
+    // Reply to bot without trigger
+    const msg = fakeMessage({
+      text: "followup question",
+      isReplyToBot: true,
+    });
+    await handler(thread, msg, true);
+
+    expect(thread.startTyping).toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledWith("Here's your answer!");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -316,6 +360,7 @@ function fakeMessage(opts: {
   userId?: string;
   userName?: string;
   isMe?: boolean;
+  isReplyToBot?: boolean;
 }): unknown {
   return {
     text: opts.text ?? "",
@@ -326,7 +371,11 @@ function fakeMessage(opts: {
       isBot: false,
       isMe: opts.isMe ?? false,
     },
-    metadata: { dateSent: new Date(), edited: false },
+    metadata: {
+      dateSent: new Date(),
+      edited: false,
+      isReplyToBot: opts.isReplyToBot ?? false,
+    },
     attachments: [],
   };
 }

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -229,3 +229,66 @@ describe("routeInput — per-group trigger config", () => {
     expect(r2.type).toBe("ignore");
   });
 });
+
+describe("routeInput — reply-to-bot behavior", () => {
+  test("reply to bot triggers response without explicit mention", () => {
+    const r = route({
+      rawText: "what about tomorrow?",
+      isReplyToBot: true,
+      callerId: "user1",
+    });
+    expect(r.type).toBe("assistant");
+    if (r.type === "assistant") {
+      expect(r.prompt).toBe("what about tomorrow?");
+    }
+  });
+
+  test("reply to bot uses full text (no trigger stripping)", () => {
+    const r = route({
+      rawText: "can you explain more?",
+      isReplyToBot: true,
+      callerId: "user1",
+    });
+    expect(r.type).toBe("assistant");
+    if (r.type === "assistant") {
+      expect(r.prompt).toBe("can you explain more?");
+    }
+  });
+
+  test("reply to bot in DM does not double-trigger", () => {
+    // DMs already auto-trigger, so reply flag shouldn't change behavior
+    const r = route({
+      rawText: "hello",
+      isDM: true,
+      isReplyToBot: true,
+      callerId: "user1",
+    });
+    expect(r.type).toBe("assistant");
+    if (r.type === "assistant") {
+      expect(r.prompt).toBe("hello");
+    }
+  });
+
+  test("non-reply without trigger is ignored", () => {
+    const r = route({
+      rawText: "random message",
+      isReplyToBot: false,
+      callerId: "user1",
+    });
+    expect(r.type).toBe("ignore");
+  });
+
+  test("reply to bot with trigger present strips trigger", () => {
+    // If user replies AND includes trigger, trigger stripping should work
+    const r = route({
+      rawText: "@Pi what about tomorrow?",
+      isReplyToBot: true,
+      callerId: "user1",
+    });
+    expect(r.type).toBe("assistant");
+    if (r.type === "assistant") {
+      // Trigger matched, so prompt is stripped
+      expect(r.prompt).toBe("what about tomorrow?");
+    }
+  });
+});


### PR DESCRIPTION
When a user replies to a bot message, treat it as a trigger — even without an explicit `@mention`.

```
User: @bot what's the weather?
Bot: It's 72°F and sunny.
User: [replies] what about tomorrow?  ← Now triggers response
Bot: Tomorrow will be 75°F.
```

## Implementation

- **WhatsApp**: Detect via `contextInfo.participant` + `isBotJid()`
- **Discord**: Detect via `msg.reference`, fetch referenced message
- **Slack**: Documented limitation (threading model differs — users typically `@` mention in threads)

Adds `isReplyToBot` flag through the message flow:
```
adapter metadata → chat-sdk → runtime → router
```

## Changes

| File | Change |
|------|--------|
| `src/core/router.ts` | Accept `isReplyToBot`, trigger on reply |
| `src/core/runtime.ts` | Pass through `isReplyToBot` |
| `src/chat-sdk.ts` | Extract from metadata, update typing indicator |
| `src/adapters/discord-native.ts` | Detect replies via `msg.reference` |
| `src/adapters/discord.ts` | Extract and pass `isReplyToBot` |
| `src/adapters/whatsapp.ts` | Detect via `isBotJid()` + `contextInfo.participant` |
| `src/adapters/slack.ts` | Placeholder with documented limitation |
| `docs/ingress.md` | Added Reply-to-Bot section |

## Tests

- 7 new tests covering reply-to-bot behavior
- All 256 tests pass

Closes #70