### PR TITLE
feat: add systemd/launchd daemon support with service commands

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,196 @@
+# Deployment
+
+Mercury can run as a background daemon with automatic restart on crash.
+
+## Quick Setup
+
+```bash
+# Install as user service (recommended)
+mercury service install
+
+# Check status
+mercury service status
+
+# View logs
+mercury service logs -f
+
+# Uninstall when needed
+mercury service uninstall
+```
+
+## Platform Support
+
+### Linux (systemd)
+
+Mercury installs as a systemd user service by default:
+
+```bash
+# Install as user service (no sudo required)
+mercury service install
+
+# Or explicitly specify user mode
+mercury service install --user
+```
+
+The service file is written to `~/.config/systemd/user/mercury.service`.
+
+**Manual systemd commands:**
+
+```bash
+# Check status
+systemctl --user status mercury
+
+# Restart service
+systemctl --user restart mercury
+
+# Stop service
+systemctl --user stop mercury
+
+# View logs (follow mode)
+journalctl --user -u mercury -f
+```
+
+**User service notes:**
+- No root/sudo required
+- Service runs under your user account
+- Starts automatically on user login
+- For 24/7 operation without login, enable lingering: `loginctl enable-linger $USER`
+
+### macOS (launchd)
+
+Mercury installs as a launchd user agent:
+
+```bash
+mercury service install
+```
+
+The plist is written to `~/Library/LaunchAgents/com.mercury.agent.plist`.
+
+Logs are written to `.mercury/logs/` in your project directory:
+- `mercury.log` — stdout
+- `mercury.error.log` — stderr
+
+**Manual launchd commands:**
+
+```bash
+# Check if running
+launchctl list com.mercury.agent
+
+# Stop service
+launchctl stop com.mercury.agent
+
+# Start service
+launchctl start com.mercury.agent
+
+# Unload completely
+launchctl unload ~/Library/LaunchAgents/com.mercury.agent.plist
+
+# View logs
+tail -f .mercury/logs/mercury.log
+```
+
+### Windows
+
+Not currently supported via `mercury service`. Options:
+
+1. **Task Scheduler**: Create a task that runs `mercury run` at startup
+2. **NSSM**: Use [NSSM](https://nssm.cc/) to wrap Mercury as a Windows service
+3. **PM2**: Use `pm2 start "mercury run" --name mercury`
+
+## Auto-Restart Behavior
+
+Both systemd and launchd are configured to automatically restart Mercury if it crashes:
+
+- **systemd**: `Restart=on-failure` with 10-second delay
+- **launchd**: `KeepAlive=true` for immediate restart
+
+## Working Directory
+
+The service is configured to run from the directory where you ran `mercury service install`. This means:
+
+- Your `.env` file is loaded from that directory
+- Relative paths in configuration resolve from there
+- The `.mercury/` data directory is in that location
+
+If you move your Mercury project, you'll need to uninstall and reinstall the service.
+
+## Logs
+
+### Linux
+
+Logs go to the systemd journal:
+
+```bash
+# View recent logs
+mercury service logs
+
+# Follow logs in real-time
+mercury service logs -f
+
+# Or use journalctl directly
+journalctl --user -u mercury -n 100
+journalctl --user -u mercury --since "1 hour ago"
+```
+
+### macOS
+
+Logs go to files in `.mercury/logs/`:
+
+```bash
+# View recent logs
+mercury service logs
+
+# Follow logs in real-time
+mercury service logs -f
+
+# Or use tail directly
+tail -f .mercury/logs/mercury.log
+```
+
+## Troubleshooting
+
+### Service fails to start
+
+1. Check that `mercury run` works manually first
+2. Verify `.env` exists and is configured
+3. Check logs for errors: `mercury service logs`
+
+### Permission denied (Linux)
+
+If you see permission errors with system-level install, use user mode:
+
+```bash
+mercury service install --user
+```
+
+### Service not found after reboot (Linux)
+
+Enable user lingering so services start without login:
+
+```bash
+loginctl enable-linger $USER
+```
+
+### Logs not appearing (macOS)
+
+Check that the log directory exists:
+
+```bash
+mkdir -p .mercury/logs
+```
+
+Then reinstall the service:
+
+```bash
+mercury service uninstall
+mercury service install
+```
+
+### Multiple instances
+
+Each Mercury project should be installed as a separate service from its own directory. The service name is always `mercury`, so only one instance can be managed per user account.
+
+For multiple instances, consider:
+- Running different instances under different user accounts
+- Using Docker/Podman with separate containers
+- Manual systemd service files with unique names

--- a/src/cli/mercury.ts
+++ b/src/cli/mercury.ts
@@ -8,8 +8,10 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
@@ -376,5 +378,369 @@ program
       dryRun: options.dryRun,
     });
   });
+
+// Service management commands
+const SERVICE_NAME = "mercury";
+const LAUNCHD_LABEL = "com.mercury.agent";
+
+function getServicePaths(): {
+  systemdUser: string;
+  systemdSystem: string;
+  launchdPlist: string;
+  logDir: string;
+} {
+  return {
+    systemdUser: join(homedir(), ".config/systemd/user/mercury.service"),
+    systemdSystem: "/etc/systemd/system/mercury.service",
+    launchdPlist: join(
+      homedir(),
+      "Library/LaunchAgents/com.mercury.agent.plist",
+    ),
+    logDir: join(CWD, ".mercury/logs"),
+  };
+}
+
+function checkCommandExists(cmd: string): boolean {
+  const result = spawnSync("which", [cmd], { stdio: "pipe" });
+  return result.status === 0;
+}
+
+function generateSystemdService(userMode: boolean): string {
+  const mercuryBin = process.argv[1];
+  const workDir = CWD;
+
+  return `[Unit]
+Description=Mercury Chat Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${mercuryBin} run
+WorkingDirectory=${workDir}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=${userMode ? "default.target" : "multi-user.target"}
+`;
+}
+
+function generateLaunchdPlist(): string {
+  const mercuryBin = process.argv[1];
+  const workDir = CWD;
+  const { logDir } = getServicePaths();
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${mercuryBin}</string>
+    <string>run</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${workDir}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${logDir}/mercury.log</string>
+  <key>StandardErrorPath</key>
+  <string>${logDir}/mercury.error.log</string>
+</dict>
+</plist>`;
+}
+
+function installSystemd(userMode: boolean): void {
+  if (!checkCommandExists("systemctl")) {
+    console.error("Error: systemctl not found. Is systemd installed?");
+    process.exit(1);
+  }
+
+  const paths = getServicePaths();
+  const servicePath = userMode ? paths.systemdUser : paths.systemdSystem;
+  const serviceContent = generateSystemdService(userMode);
+
+  // Check if we need sudo for system-level install
+  if (!userMode) {
+    console.log("Installing system-level service requires sudo.");
+    console.log("Consider using --user flag for user-level service instead.");
+  }
+
+  // Create directory if needed
+  mkdirSync(dirname(servicePath), { recursive: true });
+
+  // Write service file
+  try {
+    writeFileSync(servicePath, serviceContent);
+  } catch (err) {
+    if (!userMode) {
+      console.error(
+        "Error: Cannot write to system directory. Try with sudo or use --user flag.",
+      );
+    } else {
+      console.error(`Error writing service file: ${err}`);
+    }
+    process.exit(1);
+  }
+
+  // Enable and start service
+  const systemctlBase = userMode ? ["systemctl", "--user"] : ["systemctl"];
+
+  console.log("Reloading systemd daemon...");
+  const reloadResult = spawnSync(
+    systemctlBase[0],
+    [...systemctlBase.slice(1), "daemon-reload"],
+    {
+      stdio: "inherit",
+    },
+  );
+  if (reloadResult.status !== 0) {
+    console.error("Failed to reload systemd daemon");
+    process.exit(1);
+  }
+
+  console.log("Enabling mercury service...");
+  const enableResult = spawnSync(
+    systemctlBase[0],
+    [...systemctlBase.slice(1), "enable", SERVICE_NAME],
+    {
+      stdio: "inherit",
+    },
+  );
+  if (enableResult.status !== 0) {
+    console.error("Failed to enable service");
+    process.exit(1);
+  }
+
+  console.log("Starting mercury service...");
+  const startResult = spawnSync(
+    systemctlBase[0],
+    [...systemctlBase.slice(1), "start", SERVICE_NAME],
+    {
+      stdio: "inherit",
+    },
+  );
+  if (startResult.status !== 0) {
+    console.error("Failed to start service");
+    process.exit(1);
+  }
+
+  console.log("\n✓ Mercury service installed and started");
+  console.log(`  Service file: ${servicePath}`);
+  console.log(
+    `  View logs: journalctl ${userMode ? "--user " : ""}-u mercury -f`,
+  );
+}
+
+function installLaunchd(): void {
+  if (!checkCommandExists("launchctl")) {
+    console.error("Error: launchctl not found. Are you on macOS?");
+    process.exit(1);
+  }
+
+  const paths = getServicePaths();
+  const plistContent = generateLaunchdPlist();
+
+  // Create log directory
+  mkdirSync(paths.logDir, { recursive: true });
+
+  // Create LaunchAgents directory if needed
+  mkdirSync(dirname(paths.launchdPlist), { recursive: true });
+
+  // Unload existing service if present
+  if (existsSync(paths.launchdPlist)) {
+    spawnSync("launchctl", ["unload", paths.launchdPlist], { stdio: "pipe" });
+  }
+
+  // Write plist file
+  writeFileSync(paths.launchdPlist, plistContent);
+
+  // Load service
+  const loadResult = spawnSync("launchctl", ["load", paths.launchdPlist], {
+    stdio: "inherit",
+  });
+  if (loadResult.status !== 0) {
+    console.error("Failed to load service");
+    process.exit(1);
+  }
+
+  console.log("\n✓ Mercury service installed and started");
+  console.log(`  Plist: ${paths.launchdPlist}`);
+  console.log(`  Logs: ${paths.logDir}/mercury.log`);
+  console.log(`  View logs: tail -f ${paths.logDir}/mercury.log`);
+}
+
+function serviceInstallAction(options: { user?: boolean }): void {
+  // Verify we're in a mercury project
+  const envPath = join(CWD, ".env");
+  if (!existsSync(envPath)) {
+    console.error("Error: .env file not found in current directory.");
+    console.error("Run 'mercury init' first, or cd into your mercury project.");
+    process.exit(1);
+  }
+
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    installLaunchd();
+  } else if (platform === "linux") {
+    // Default to user mode unless explicitly installing system-wide
+    installSystemd(options.user ?? true);
+  } else {
+    console.error(`Unsupported platform: ${platform}`);
+    console.log("See docs/deployment.md for manual setup instructions.");
+    process.exit(1);
+  }
+}
+
+function serviceUninstallAction(): void {
+  const platform = process.platform;
+  const paths = getServicePaths();
+
+  if (platform === "darwin") {
+    if (existsSync(paths.launchdPlist)) {
+      console.log("Unloading mercury service...");
+      spawnSync("launchctl", ["unload", paths.launchdPlist], {
+        stdio: "inherit",
+      });
+      unlinkSync(paths.launchdPlist);
+      console.log("✓ Mercury service uninstalled");
+    } else {
+      console.log("Service not installed");
+    }
+  } else if (platform === "linux") {
+    // Try user service first, then system
+    if (existsSync(paths.systemdUser)) {
+      console.log("Stopping mercury user service...");
+      spawnSync("systemctl", ["--user", "stop", SERVICE_NAME], {
+        stdio: "inherit",
+      });
+      console.log("Disabling mercury user service...");
+      spawnSync("systemctl", ["--user", "disable", SERVICE_NAME], {
+        stdio: "inherit",
+      });
+      unlinkSync(paths.systemdUser);
+      spawnSync("systemctl", ["--user", "daemon-reload"], { stdio: "inherit" });
+      console.log("✓ Mercury user service uninstalled");
+    } else if (existsSync(paths.systemdSystem)) {
+      console.log("Stopping mercury system service...");
+      spawnSync("systemctl", ["stop", SERVICE_NAME], { stdio: "inherit" });
+      console.log("Disabling mercury system service...");
+      spawnSync("systemctl", ["disable", SERVICE_NAME], { stdio: "inherit" });
+      try {
+        unlinkSync(paths.systemdSystem);
+      } catch {
+        console.error(
+          "Error: Cannot remove system service file. Try with sudo.",
+        );
+        process.exit(1);
+      }
+      spawnSync("systemctl", ["daemon-reload"], { stdio: "inherit" });
+      console.log("✓ Mercury system service uninstalled");
+    } else {
+      console.log("Service not installed");
+    }
+  } else {
+    console.error(`Unsupported platform: ${platform}`);
+    process.exit(1);
+  }
+}
+
+function serviceStatusAction(): void {
+  const platform = process.platform;
+  const paths = getServicePaths();
+
+  if (platform === "darwin") {
+    if (!existsSync(paths.launchdPlist)) {
+      console.log("Mercury service is not installed");
+      return;
+    }
+    console.log("Mercury service status:\n");
+    spawnSync("launchctl", ["list", LAUNCHD_LABEL], { stdio: "inherit" });
+  } else if (platform === "linux") {
+    // Try user service first
+    if (existsSync(paths.systemdUser)) {
+      spawnSync("systemctl", ["--user", "status", SERVICE_NAME], {
+        stdio: "inherit",
+      });
+    } else if (existsSync(paths.systemdSystem)) {
+      spawnSync("systemctl", ["status", SERVICE_NAME], { stdio: "inherit" });
+    } else {
+      console.log("Mercury service is not installed");
+    }
+  } else {
+    console.error(`Unsupported platform: ${platform}`);
+    process.exit(1);
+  }
+}
+
+function serviceLogsAction(options: { follow?: boolean }): void {
+  const platform = process.platform;
+  const paths = getServicePaths();
+
+  if (platform === "darwin") {
+    const logPath = join(paths.logDir, "mercury.log");
+    if (!existsSync(logPath)) {
+      console.error(`Log file not found: ${logPath}`);
+      console.log("The service may not have been started yet.");
+      process.exit(1);
+    }
+    const args = options.follow ? ["-f", logPath] : ["-n", "100", logPath];
+    spawnSync("tail", args, { stdio: "inherit" });
+  } else if (platform === "linux") {
+    // Determine if user or system service
+    const isUserService = existsSync(paths.systemdUser);
+    const isSystemService = existsSync(paths.systemdSystem);
+
+    if (!isUserService && !isSystemService) {
+      console.error("Mercury service is not installed");
+      process.exit(1);
+    }
+
+    const args = isUserService
+      ? ["--user", "-u", SERVICE_NAME]
+      : ["-u", SERVICE_NAME];
+    if (options.follow) args.push("-f");
+    spawnSync("journalctl", args, { stdio: "inherit" });
+  } else {
+    console.error(`Unsupported platform: ${platform}`);
+    process.exit(1);
+  }
+}
+
+// Service subcommand
+const serviceCommand = program
+  .command("service")
+  .description("Manage Mercury as a system service");
+
+serviceCommand
+  .command("install")
+  .description("Install Mercury as a system service")
+  .option(
+    "--user",
+    "Install as user service (default on Linux, no sudo required)",
+  )
+  .action(serviceInstallAction);
+
+serviceCommand
+  .command("uninstall")
+  .description("Uninstall Mercury service")
+  .action(serviceUninstallAction);
+
+serviceCommand
+  .command("status")
+  .description("Show service status")
+  .action(serviceStatusAction);
+
+serviceCommand
+  .command("logs")
+  .description("View service logs")
+  .option("-f, --follow", "Follow log output")
+  .action(serviceLogsAction);
 
 program.parse();


### PR DESCRIPTION
## Summary

Add `mercury service` subcommand group for managing Mercury as a system service.

## Changes

### New Commands

| Command | Description |
|---------|-------------|
| `mercury service install [--user]` | Install as systemd (Linux) or launchd (macOS) service |
| `mercury service uninstall` | Remove service cleanly |
| `mercury service status` | Show running state |
| `mercury service logs [-f]` | View/tail logs |

### Platform Support

| Feature | Linux (systemd) | macOS (launchd) |
|---------|-----------------|-----------------|
| Service file | `~/.config/systemd/user/mercury.service` | `~/Library/LaunchAgents/com.mercury.agent.plist` |
| Auto-restart | `Restart=on-failure` (10s delay) | `KeepAlive=true` |
| Logs | journalctl | `.mercury/logs/mercury.log` |
| User mode | `--user` flag (default) | Always user agent |

### Documentation

Added `docs/deployment.md` with:
- Quick setup instructions
- Platform-specific details (Linux/macOS/Windows)
- Manual commands reference
- Troubleshooting guide

## Testing

- `bun run check` passes (typecheck + lint + 267 tests)
- CLI help displays correctly for all service subcommands
- Platform detection works correctly

Closes #65