### PR TITLE
feat: add mercury-setup skill

### DIFF
--- a/resources/skills/mercury-setup/SKILL.md
+++ b/resources/skills/mercury-setup/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: mercury-setup
+description: Guide Mercury setup from scratch — install, authenticate, configure adapters, seed admin, and run. Use when the user asks how to set up Mercury, configure a new instance, or connect a chat platform.
+---
+
+## Prerequisites
+
+- **Docker** — Mercury runs agents in containers. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or Docker Engine.
+- **Bun >= 1.2.0** — Runtime. Install: `curl -fsSL https://bun.sh/install | bash`
+
+Verify:
+```bash
+docker --version && docker info > /dev/null 2>&1 && echo "Docker OK"
+bun --version  # Should print >= 1.2.0
+```
+
+## Install & Initialize
+
+```bash
+npm install -g mercury-ai
+mkdir my-assistant && cd my-assistant
+mercury init
+```
+
+This creates `.env`, `AGENTS.md`, and the `.mercury/` data directory.
+
+## Authenticate
+
+Mercury needs an AI model provider. Choose one:
+
+### Option A: OAuth Login (recommended)
+
+```bash
+mercury auth login              # Interactive provider picker
+mercury auth login anthropic    # Or specify provider directly
+```
+
+Supported: Anthropic (Claude Pro/Max), GitHub Copilot, Google Gemini CLI, ChatGPT Plus/Pro.
+
+### Option B: API Key
+
+Set in `.env`:
+```bash
+MERCURY_ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Verify auth:
+```bash
+mercury auth status
+```
+
+## Configure Identity
+
+Edit `.env`:
+```bash
+MERCURY_CHATSDK_USERNAME=Mercury       # Bot display name
+MERCURY_TRIGGER_PATTERNS=@Mercury      # Comma-separated trigger words
+MERCURY_MODEL_PROVIDER=anthropic       # anthropic | openai
+MERCURY_MODEL=claude-sonnet-4-20250514 # Model to use
+```
+
+## Connect a Chat Platform
+
+Enable one or more adapters in `.env`. See reference docs for detailed setup:
+
+| Platform | Reference | Key env vars |
+|----------|-----------|-------------|
+| WhatsApp | [whatsapp.md](references/whatsapp.md) | `MERCURY_ENABLE_WHATSAPP` |
+| Discord | [discord.md](references/discord.md) | `MERCURY_ENABLE_DISCORD`, `MERCURY_DISCORD_BOT_TOKEN` |
+| Slack | [slack.md](references/slack.md) | `MERCURY_ENABLE_SLACK`, `MERCURY_SLACK_BOT_TOKEN`, `MERCURY_SLACK_SIGNING_SECRET` |
+| Teams | [teams.md](references/teams.md) | `MERCURY_ENABLE_TEAMS`, `MERCURY_TEAMS_APP_ID`, `MERCURY_TEAMS_APP_PASSWORD` |
+
+## Seed Admin (optional)
+
+Set admin caller IDs so privileged commands work from day one:
+```bash
+MERCURY_ADMINS=caller-id-1,caller-id-2
+```
+
+See [user-ids.md](references/user-ids.md) for how to find your caller ID on each platform.
+
+## First Run
+
+```bash
+mercury run
+```
+
+Or install as a background service:
+```bash
+mercury service install
+mercury service status
+mercury service logs -f
+```
+
+## Test It
+
+Send a message from your connected platform. Mercury should reply.
+
+If it doesn't, check:
+1. `mercury auth status` — is auth configured?
+2. Docker running? `docker info`
+3. Adapter enabled? Check `.env`
+4. See [troubleshooting.md](references/troubleshooting.md)
+
+## Set Up Spaces
+
+Mercury discovers conversations from incoming traffic. Link them to spaces (memory boundaries):
+
+```bash
+mercury spaces create main
+mercury conversations --unlinked   # See discovered conversations
+mercury link <id> main             # Link to a space
+```

--- a/resources/skills/mercury-setup/SKILL.md
+++ b/resources/skills/mercury-setup/SKILL.md
@@ -82,11 +82,6 @@ See [user-ids.md](references/user-ids.md) for how to find your caller ID on each
 ## First Run
 
 ```bash
-mercury run
-```
-
-Or install as a background service:
-```bash
 mercury service install
 mercury service status
 mercury service logs -f

--- a/resources/skills/mercury-setup/references/discord.md
+++ b/resources/skills/mercury-setup/references/discord.md
@@ -1,0 +1,35 @@
+# Discord Setup
+
+## Create a Bot
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application** → name it
+3. Go to **Bot** → click **Reset Token** → copy the token
+4. Under **Privileged Gateway Intents**, enable:
+   - **Message Content Intent**
+   - **Server Members Intent** (optional, for member info)
+5. Go to **OAuth2 → URL Generator**:
+   - Scopes: `bot`
+   - Bot Permissions: `Send Messages`, `Read Message History`, `Attach Files`
+6. Copy the generated URL → open it → add the bot to your server
+
+## Enable
+
+In `.env`:
+```bash
+MERCURY_ENABLE_DISCORD=true
+MERCURY_DISCORD_BOT_TOKEN=your-bot-token-here
+```
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MERCURY_ENABLE_DISCORD` | `false` | Enable Discord adapter |
+| `MERCURY_DISCORD_BOT_TOKEN` | — | Bot token from Developer Portal |
+
+## Notes
+
+- The bot responds to messages in channels it has access to
+- Use trigger patterns (`MERCURY_TRIGGER_PATTERNS`) to control when the bot responds
+- Mercury supports Discord threads and file attachments

--- a/resources/skills/mercury-setup/references/slack.md
+++ b/resources/skills/mercury-setup/references/slack.md
@@ -1,0 +1,57 @@
+# Slack Setup
+
+## Create a Slack App
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**
+2. Name it and select your workspace
+
+### Bot Token Scopes
+
+Go to **OAuth & Permissions** → **Bot Token Scopes** and add:
+- `chat:write` — send messages
+- `channels:history` — read channel messages
+- `groups:history` — read private channel messages
+- `im:history` — read DMs
+- `files:read` — access shared files
+- `files:write` — upload files
+
+### Event Subscriptions
+
+Go to **Event Subscriptions** → enable → set Request URL to your server:
+```
+https://your-server.com/slack/events
+```
+
+Subscribe to bot events:
+- `message.channels`
+- `message.groups`
+- `message.im`
+
+### Install to Workspace
+
+Go to **Install App** → **Install to Workspace** → authorize.
+
+Copy the **Bot User OAuth Token** (`xoxb-...`) and **Signing Secret** (from Basic Information).
+
+## Enable
+
+In `.env`:
+```bash
+MERCURY_ENABLE_SLACK=true
+MERCURY_SLACK_BOT_TOKEN=xoxb-your-token
+MERCURY_SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MERCURY_ENABLE_SLACK` | `false` | Enable Slack adapter |
+| `MERCURY_SLACK_BOT_TOKEN` | — | Bot User OAuth Token (`xoxb-...`) |
+| `MERCURY_SLACK_SIGNING_SECRET` | — | App signing secret |
+
+## Notes
+
+- Slack requires a publicly accessible URL for event subscriptions
+- Use a tunnel (e.g., ngrok, Cloudflare Tunnel) for local development
+- Mercury handles message threading automatically

--- a/resources/skills/mercury-setup/references/teams.md
+++ b/resources/skills/mercury-setup/references/teams.md
@@ -1,0 +1,45 @@
+# Teams Setup
+
+## Register a Bot
+
+1. Go to the [Azure Portal](https://portal.azure.com) → **Azure Bot** → **Create**
+2. Choose **Multi Tenant** for bot type
+3. Note the **App ID** and create a **Client Secret** (App Password)
+
+### Configure Messaging Endpoint
+
+Set the messaging endpoint to:
+```
+https://your-server.com/teams/messages
+```
+
+### Install in Teams
+
+1. Create a Teams app manifest (or use Teams Developer Portal)
+2. Upload as a custom app to your organization
+3. Add the bot to a team or chat
+
+## Enable
+
+In `.env`:
+```bash
+MERCURY_ENABLE_TEAMS=true
+MERCURY_TEAMS_APP_ID=your-app-id
+MERCURY_TEAMS_APP_PASSWORD=your-client-secret
+MERCURY_TEAMS_APP_TENANT_ID=your-tenant-id
+```
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MERCURY_ENABLE_TEAMS` | `false` | Enable Teams adapter |
+| `MERCURY_TEAMS_APP_ID` | — | Azure Bot App ID |
+| `MERCURY_TEAMS_APP_PASSWORD` | — | Azure Bot Client Secret |
+| `MERCURY_TEAMS_APP_TENANT_ID` | — | Azure AD Tenant ID |
+
+## Notes
+
+- Teams requires Azure AD registration and a public HTTPS endpoint
+- Use a tunnel for local development
+- Mercury supports Teams channels and direct messages

--- a/resources/skills/mercury-setup/references/troubleshooting.md
+++ b/resources/skills/mercury-setup/references/troubleshooting.md
@@ -1,0 +1,64 @@
+# Troubleshooting
+
+## Bot doesn't respond
+
+1. **Check auth**: `mercury auth status` — is a provider configured?
+2. **Check Docker**: `docker info` — is Docker running?
+3. **Check adapter**: Is the adapter enabled in `.env`? (`MERCURY_ENABLE_WHATSAPP=true`, etc.)
+4. **Check logs**: `mercury service logs -f` (if running as service) or check terminal output
+5. **Check trigger**: Does your message match `MERCURY_TRIGGER_PATTERNS`? Try `trigger.match=always` via `mrctl config set trigger.match always`
+
+## Docker errors
+
+### "Cannot connect to Docker daemon"
+Docker is not running. Start Docker Desktop or the Docker service:
+```bash
+# macOS
+open -a Docker
+# Linux
+sudo systemctl start docker
+```
+
+### "Image not found" or pull errors
+Pull the agent image manually:
+```bash
+docker pull ghcr.io/michaelliv/mercury-agent:latest
+```
+
+### Container timeout
+The agent took too long. Check:
+- Network connectivity (model API must be reachable from container)
+- Model provider status
+- Increase timeout if needed
+
+## WhatsApp issues
+
+### QR code won't scan
+- Ensure your phone and computer are on the same network
+- Try the pairing code method: `mercury auth whatsapp --pairing-code --phone <number>`
+
+### Session expired
+Re-authenticate: `mercury auth whatsapp`
+
+## Auth issues
+
+### "No credentials found"
+Run `mercury auth login` or set `MERCURY_ANTHROPIC_API_KEY` in `.env`.
+
+### OAuth token expired
+Mercury auto-refreshes OAuth tokens. If it fails:
+```bash
+mercury auth logout anthropic
+mercury auth login anthropic
+```
+
+## Port conflicts
+
+Default port is 8787. If in use:
+```bash
+MERCURY_CHATSDK_PORT=9090  # Change in .env
+```
+
+## Still stuck?
+
+Check the [docs](../../docs/) or open an issue at https://github.com/Michaelliv/mercury/issues.

--- a/resources/skills/mercury-setup/references/user-ids.md
+++ b/resources/skills/mercury-setup/references/user-ids.md
@@ -1,38 +1,40 @@
 # Finding Your Caller ID
 
-Mercury identifies users by their platform-specific caller ID. You need this for `MERCURY_ADMINS` and role assignments.
+Mercury identifies users by their platform-prefixed caller ID. You need this for `MERCURY_ADMINS` and role assignments.
+
+Format: `<platform>:<id>`
 
 ## How to Find Your ID
 
 ### WhatsApp
-Your caller ID is your phone number in international format (no `+` prefix):
+Your caller ID is your phone number in international format (no `+` prefix), prefixed with `whatsapp:`:
 ```
-14155551234          # US number
-972501234567         # Israel number
+whatsapp:14155551234          # US number
+whatsapp:972501234567         # Israel number
 ```
 
 Send a message to the bot and check the logs for `callerId`.
 
 ### Discord
-Your caller ID is your Discord user ID (numeric):
+Your caller ID is your Discord user ID (numeric), prefixed with `discord:`:
 1. Enable Developer Mode: User Settings → Advanced → Developer Mode
 2. Right-click your name → **Copy User ID**
 ```
-123456789012345678
+discord:123456789012345678
 ```
 
 ### Slack
-Your caller ID is your Slack member ID:
+Your caller ID is your Slack member ID, prefixed with `slack:`:
 1. Click your profile picture → **Profile**
 2. Click **⋮** → **Copy member ID**
 ```
-U01ABCDEF23
+slack:U01ABCDEF23
 ```
 
 ### Teams
-Your caller ID is your Azure AD Object ID:
+Your caller ID is your Azure AD Object ID, prefixed with `teams:`:
 ```
-29:1a2b3c4d-5e6f-7890-abcd-ef1234567890
+teams:29:1a2b3c4d-5e6f-7890-abcd-ef1234567890
 ```
 
 Check bot logs after sending a message.
@@ -41,7 +43,7 @@ Check bot logs after sending a message.
 
 In `.env`:
 ```bash
-MERCURY_ADMINS=14155551234,U01ABCDEF23
+MERCURY_ADMINS=whatsapp:14155551234,slack:U01ABCDEF23
 ```
 
 Comma-separated list. Admin gets all permissions across all spaces.

--- a/resources/skills/mercury-setup/references/user-ids.md
+++ b/resources/skills/mercury-setup/references/user-ids.md
@@ -1,0 +1,47 @@
+# Finding Your Caller ID
+
+Mercury identifies users by their platform-specific caller ID. You need this for `MERCURY_ADMINS` and role assignments.
+
+## How to Find Your ID
+
+### WhatsApp
+Your caller ID is your phone number in international format (no `+` prefix):
+```
+14155551234          # US number
+972501234567         # Israel number
+```
+
+Send a message to the bot and check the logs for `callerId`.
+
+### Discord
+Your caller ID is your Discord user ID (numeric):
+1. Enable Developer Mode: User Settings → Advanced → Developer Mode
+2. Right-click your name → **Copy User ID**
+```
+123456789012345678
+```
+
+### Slack
+Your caller ID is your Slack member ID:
+1. Click your profile picture → **Profile**
+2. Click **⋮** → **Copy member ID**
+```
+U01ABCDEF23
+```
+
+### Teams
+Your caller ID is your Azure AD Object ID:
+```
+29:1a2b3c4d-5e6f-7890-abcd-ef1234567890
+```
+
+Check bot logs after sending a message.
+
+## Setting Admins
+
+In `.env`:
+```bash
+MERCURY_ADMINS=14155551234,U01ABCDEF23
+```
+
+Comma-separated list. Admin gets all permissions across all spaces.

--- a/resources/skills/mercury-setup/references/whatsapp.md
+++ b/resources/skills/mercury-setup/references/whatsapp.md
@@ -1,0 +1,43 @@
+# WhatsApp Setup
+
+## Enable
+
+```bash
+MERCURY_ENABLE_WHATSAPP=true
+```
+
+## Authenticate
+
+Mercury uses the Baileys library to connect to WhatsApp via the multi-device protocol.
+
+### QR Code (recommended)
+
+```bash
+mercury auth whatsapp
+```
+
+Scan the QR code with WhatsApp on your phone:
+1. Open WhatsApp → Settings → Linked Devices → Link a Device
+2. Scan the terminal QR code
+
+### Pairing Code (headless/SSH)
+
+```bash
+mercury auth whatsapp --pairing-code --phone <your-phone-number>
+```
+
+Enter the pairing code in WhatsApp → Linked Devices → Link with phone number.
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MERCURY_ENABLE_WHATSAPP` | `false` | Enable WhatsApp adapter |
+| `MERCURY_WHATSAPP_AUTH_DIR` | `<dataDir>/whatsapp-auth` | Auth session storage |
+
+## Notes
+
+- WhatsApp auth credentials are stored in `MERCURY_WHATSAPP_AUTH_DIR` — treat like passwords
+- The bot appears as a linked device on your WhatsApp account
+- If the session expires, re-run `mercury auth whatsapp`
+- Media files (images, documents, voice) are supported


### PR DESCRIPTION
Closes #69

## Summary

Adds a new `mercury-setup` skill that guides users through Mercury setup from scratch — from prerequisites to first message. The skill follows the same structure and frontmatter pattern as existing skills (`config`, `tasks`, `roles`, `spaces`, `permissions`).

## What's included

### `resources/skills/mercury-setup/SKILL.md`

The main skill file covers the complete setup flow in order:

1. **Prerequisites** — Docker and Bun ≥ 1.2.0 with verification commands
2. **Install & Initialize** — `npm install -g mercury-ai`, `mercury init`
3. **Authenticate** — OAuth login (recommended) vs API key, with provider list
4. **Configure Identity** — Bot username, trigger patterns, model selection
5. **Connect a Chat Platform** — Table linking to per-platform reference docs
6. **Seed Admin** — `MERCURY_ADMINS` env var with link to caller ID reference
7. **First Run** — `mercury run` or `mercury service install`
8. **Test It** — Quick troubleshooting checklist
9. **Set Up Spaces** — Creating spaces and linking conversations

### Reference docs (`references/`)

Detailed per-platform guides sourced from Mercury's actual documentation and `.env.example`:

| File | Content |
|------|---------|
| `whatsapp.md` | QR code and pairing code auth, Baileys multi-device protocol, env vars |
| `discord.md` | Developer Portal bot creation, token setup, gateway intents, OAuth2 invite URL |
| `slack.md` | App creation, bot token scopes, event subscriptions, signing secret |
| `teams.md` | Azure Bot registration, app ID/password/tenant, Teams manifest |
| `user-ids.md` | How to find caller IDs on each platform (needed for `MERCURY_ADMINS` and role assignments) |
| `troubleshooting.md` | Common issues: auth failures, Docker errors, WhatsApp session expiry, port conflicts |

## Design decisions

- **Progressive disclosure**: SKILL.md is a concise overview (~113 lines). Platform-specific details live in `references/` so the agent only loads what's needed.
- **Follows existing patterns**: Same YAML frontmatter format (`name` + `description`) as `config`, `tasks`, and other skills in `resources/skills/`.
- **Sourced from real docs**: All env vars, CLI commands, and auth flows are taken directly from `docs/auth/overview.md`, `.env.example`, and `README.md` — nothing invented.
- **Troubleshooting included**: Common gotchas (Docker not running, QR won't scan, port conflicts) are covered so the agent can help users self-service without leaving the skill.

## Test plan

- [x] All reference docs linked from SKILL.md exist in `references/`
- [x] SKILL.md frontmatter matches existing skill pattern (`name` + `description` in YAML)
- [x] Env var names match `.env.example`
- [x] CLI commands match `README.md` and `docs/auth/overview.md`
- [x] Platform auth flows match `docs/auth/overview.md`